### PR TITLE
Remove useless dependences

### DIFF
--- a/src/System.Linq.Dynamic.Core/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/ExpressionParser.cs
@@ -282,27 +282,29 @@ namespace System.Linq.Dynamic.Core
             try
             {
                 Type efType;
-                //EF5, System.Data.Objects.DataClasses.EdmFunctionAttribute
-                efType = Type.GetType("System.Data.Objects.EntityFunctions");
+                //EF5(or 4.x??), System.Data.Objects.DataClasses.EdmFunctionAttribute
+                //There is also an System.Data.Entity, Version=3.5.0.0, but no Functions.
+                efType = Type.GetType("System.Data.Objects.EntityFunctions, System.Data.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
-                efType = Type.GetType("System.Data.Objects.SqlClient.SqlFunctions");
+                efType = Type.GetType("System.Data.Objects.SqlClient.SqlFunctions, System.Data.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
-                efType = Type.GetType("System.Data.Objects.SqlClient.SqlSpatialFunctions");
+                efType = Type.GetType("System.Data.Objects.SqlClient.SqlSpatialFunctions, System.Data.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
+
                 //EF6,System.Data.Entity.DbFunctionAttribute
-                efType = Type.GetType("System.Data.Entity.Core.Objects.EntityFunctions");
+                efType = Type.GetType("System.Data.Entity.Core.Objects.EntityFunctions, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
-                efType = Type.GetType("System.Data.Entity.DbFunctions");
+                efType = Type.GetType("System.Data.Entity.DbFunctions, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
-                efType = Type.GetType("System.Data.Entity.SqlServer.SqlFunctions");
+                efType = Type.GetType("System.Data.Entity.SqlServer.SqlFunctions, EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
-                efType = Type.GetType("System.Data.Entity.SqlServer.SqlSpatialFunctions");
+                efType = Type.GetType("System.Data.Entity.SqlServer.SqlSpatialFunctions, EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
                     _predefinedTypes.Add(efType);
             }

--- a/src/System.Linq.Dynamic.Core/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/ExpressionParser.cs
@@ -205,29 +205,29 @@ namespace System.Linq.Dynamic.Core
             { "bool", typeof(bool) },
             { "float", typeof(float) },
         };
-        static readonly HashSet<Type> _predefinedTypes = new HashSet<Type>() {
-            typeof(object),
-            typeof(bool),
-            typeof(char),
-            typeof(string),
-            typeof(sbyte),
-            typeof(byte),
-            typeof(short),
-            typeof(ushort),
-            typeof(int),
-            typeof(uint),
-            typeof(long),
-            typeof(ulong),
-            typeof(float),
-            typeof(double),
-            typeof(decimal),
-            typeof(DateTime),
-            typeof(DateTimeOffset),
-            typeof(TimeSpan),
-            typeof(Guid),
-            typeof(Math),
-            typeof(Convert),
-            typeof(Uri)
+        static readonly Dictionary<Type, int> _predefinedTypes = new Dictionary<Type, int>() {
+            { typeof(object), 0 },
+            { typeof(bool), 0 },
+            { typeof(char), 0 },
+            { typeof(string), 0 },
+            { typeof(sbyte), 0 },
+            { typeof(byte), 0 },
+            { typeof(short), 0 },
+            { typeof(ushort), 0 },
+            { typeof(int), 0 },
+            { typeof(uint), 0 },
+            { typeof(long), 0 },
+            { typeof(ulong), 0 },
+            { typeof(float), 0 },
+            { typeof(double), 0 },
+            { typeof(decimal), 0 },
+            { typeof(DateTime), 0 },
+            { typeof(DateTimeOffset), 0 },
+            { typeof(TimeSpan), 0 },
+            { typeof(Guid), 0 },
+            { typeof(Math), 0 },
+            { typeof(Convert), 0 },
+            { typeof(Uri), 0 }
         };
 
         // These aliases are supposed to simply the where clause and make it more human readable
@@ -281,32 +281,33 @@ namespace System.Linq.Dynamic.Core
 #if !(NET35 || SILVERLIGHT || NETFX_CORE || DNXCORE50 || DOTNET5_4 || NETSTANDARD)
             try
             {
+                //System.Data.Entity is always here, so overwrite short name of it with EntityFramework if EntityFramework is found.
                 Type efType;
                 //EF5(or 4.x??), System.Data.Objects.DataClasses.EdmFunctionAttribute
                 //There is also an System.Data.Entity, Version=3.5.0.0, but no Functions.
                 efType = Type.GetType("System.Data.Objects.EntityFunctions, System.Data.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 1);
                 efType = Type.GetType("System.Data.Objects.SqlClient.SqlFunctions, System.Data.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 1);
                 efType = Type.GetType("System.Data.Objects.SqlClient.SqlSpatialFunctions, System.Data.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 1);
 
                 //EF6,System.Data.Entity.DbFunctionAttribute
                 efType = Type.GetType("System.Data.Entity.Core.Objects.EntityFunctions, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 2);
                 efType = Type.GetType("System.Data.Entity.DbFunctions, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 2);
                 efType = Type.GetType("System.Data.Entity.SqlServer.SqlFunctions, EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 2);
                 efType = Type.GetType("System.Data.Entity.SqlServer.SqlSpatialFunctions, EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
                 if (efType != null)
-                    _predefinedTypes.Add(efType);
+                    _predefinedTypes.Add(efType, 2);
             }
             catch { }
 #endif
@@ -1359,7 +1360,7 @@ namespace System.Linq.Dynamic.Core
 
         static bool IsPredefinedType(Type type)
         {
-            if (_predefinedTypes.Contains(type)) return true;
+            if (_predefinedTypes.ContainsKey(type)) return true;
             if (GlobalConfig.CustomTypeProvider.GetCustomTypes().Contains(type)) return true;
 
             return false;
@@ -2501,7 +2502,7 @@ namespace System.Linq.Dynamic.Core
             d.Add(KEYWORD_IIF, KEYWORD_IIF);
             d.Add(KEYWORD_NEW, KEYWORD_NEW);
 
-            foreach (Type type in _predefinedTypes)
+             foreach (Type type in _predefinedTypes.OrderBy(kvp => kvp.Value).Select(kvp => kvp.Key))
             {
                 d[type.FullName] = type;
                 d[type.Name] = type;

--- a/src/System.Linq.Dynamic.Core/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/ExpressionParser.cs
@@ -227,10 +227,7 @@ namespace System.Linq.Dynamic.Core
             typeof(Guid),
             typeof(Math),
             typeof(Convert),
-            typeof(Uri),
-#if !(NET35 || SILVERLIGHT || NETFX_CORE || DNXCORE50 || DOTNET5_4 || NETSTANDARD)
-			typeof(Data.Objects.EntityFunctions)
-#endif
+            typeof(Uri)
         };
 
         // These aliases are supposed to simply the where clause and make it more human readable
@@ -278,6 +275,40 @@ namespace System.Linq.Dynamic.Core
         readonly int _textLen;
         char _ch;
         Token _token;
+
+        static ExpressionParser()
+        {
+#if !(NET35 || SILVERLIGHT || NETFX_CORE || DNXCORE50 || DOTNET5_4 || NETSTANDARD)
+            try
+            {
+                Type efType;
+                //EF5, System.Data.Objects.DataClasses.EdmFunctionAttribute
+                efType = Type.GetType("System.Data.Objects.EntityFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+                efType = Type.GetType("System.Data.Objects.SqlClient.SqlFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+                efType = Type.GetType("System.Data.Objects.SqlClient.SqlSpatialFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+                //EF6,System.Data.Entity.DbFunctionAttribute
+                efType = Type.GetType("System.Data.Entity.Core.Objects.EntityFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+                efType = Type.GetType("System.Data.Entity.DbFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+                efType = Type.GetType("System.Data.Entity.SqlServer.SqlFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+                efType = Type.GetType("System.Data.Entity.SqlServer.SqlSpatialFunctions");
+                if (efType != null)
+                    _predefinedTypes.Add(efType);
+            }
+            catch { }
+#endif
+        }
 
         public ExpressionParser(ParameterExpression[] parameters, string expression, object[] values)
         {

--- a/src/System.Linq.Dynamic.Core/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/ExpressionParser.cs
@@ -2501,9 +2501,17 @@ namespace System.Linq.Dynamic.Core
             d.Add(KEYWORD_IIF, KEYWORD_IIF);
             d.Add(KEYWORD_NEW, KEYWORD_NEW);
 
-            foreach (Type type in _predefinedTypes) d.Add(type.Name, type);
+            foreach (Type type in _predefinedTypes)
+            {
+                d[type.FullName] = type;
+                d[type.Name] = type;
+            }
             foreach (KeyValuePair<string, Type> pair in _predefinedTypesShorthands) d.Add(pair.Key, pair.Value);
-            foreach (Type type in GlobalConfig.CustomTypeProvider.GetCustomTypes()) d.Add(type.Name, type);
+            foreach (Type type in GlobalConfig.CustomTypeProvider.GetCustomTypes())
+            {
+                d[type.FullName] = type;
+                d[type.Name] = type;
+            }
 
             return d;
         }

--- a/src/System.Linq.Dynamic.Core/GroupResult.cs
+++ b/src/System.Linq.Dynamic.Core/GroupResult.cs
@@ -38,7 +38,7 @@ namespace System.Linq.Dynamic.Core
         /// </summary>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", Key, Count);
+            return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", ((object)Key).ToString(), Count);
         }
     }
 }

--- a/src/System.Linq.Dynamic.Core/project.json
+++ b/src/System.Linq.Dynamic.Core/project.json
@@ -27,7 +27,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "net45": {
@@ -35,7 +34,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "net451": {
@@ -43,7 +41,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "net452": {
@@ -51,7 +48,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "net461": {
@@ -59,7 +55,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "dnx451": {
@@ -67,7 +62,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "dnx452": {
@@ -75,7 +69,6 @@
                 "JetBrains.Annotations": "10.1.4"
             },
             "frameworkAssemblies": {
-                "System.Data.Entity": ""
             }
         },
         "dnxcore5": {

--- a/src/System.Linq.Dynamic.Core/project.json
+++ b/src/System.Linq.Dynamic.Core/project.json
@@ -58,66 +58,24 @@
         },
         "dnxcore5": {
             "dependencies": {
-                "Microsoft.CSharp": "4.0.1-beta-*",
-
-                "System.Collections.Concurrent": "4.0.11-beta-*",
-
                 "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc1-final",
-
-                "System.Runtime.Extensions": "4.0.11-beta-*",
-                "System.Runtime.InteropServices": "4.0.21-beta-*",
-                "System.Runtime.Loader": "4.0.0-beta-*",
-
-                "System.Runtime.Serialization.Primitives": "4.1.0-beta-*",
-                "System.Runtime.Serialization.Xml": "4.1.0-beta-*",
-
-                "System.Reflection.Primitives": "4.0.1-beta-*",
-                "System.Reflection.TypeExtensions": "4.1.0-beta-*",
-                "System.Reflection.Emit": "4.0.1-beta-*",
-
-                "System.Linq": "4.0.1-beta-*",
-                "System.Linq.Expressions": "4.0.11-beta-*",
-                "System.Linq.Queryable": "4.0.1-beta-*",
-
-                "System.Globalization": "4.0.11-beta-*",
-
-                "System.Diagnostics.Debug": "4.0.11-beta-*",
-                "System.Diagnostics.Tools": "4.0.1-beta-*",
-                "System.Diagnostics.Tracing": "4.0.21-beta-*",
-
-                "System.Threading": "4.0.11-beta-*"
+                "System.Collections.Concurrent": "4.0.11-*",
+                "System.Dynamic.Runtime": "4.0.11-*",
+                "System.Reflection.Emit": "4.0.1-*",
+                "System.Reflection.TypeExtensions": "4.1.0-*",
+                "System.Linq.Expressions": "4.0.11-*",
+                "System.Linq.Queryable": "4.0.1-*"
             }
         },
         "dotnet54": {
             "dependencies": {
-                "Microsoft.CSharp": "4.0.1-beta-*",
-
-                "System.Collections.Concurrent": "4.0.11-beta-*",
-
                 "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc1-final",
-
-                "System.Runtime.Extensions": "4.0.11-beta-*",
-                "System.Runtime.InteropServices": "4.0.21-beta-*",
-                "System.Runtime.Loader": "4.0.0-beta-*",
-
-                "System.Runtime.Serialization.Primitives": "4.1.0-beta-*",
-                "System.Runtime.Serialization.Xml": "4.1.0-beta-*",
-
-                "System.Reflection.Primitives": "4.0.1-beta-*",
-                "System.Reflection.TypeExtensions": "4.1.0-beta-*",
-                "System.Reflection.Emit": "4.0.1-beta-*",
-
-                "System.Linq": "4.0.1-beta-*",
-                "System.Linq.Expressions": "4.0.11-beta-*",
-                "System.Linq.Queryable": "4.0.1-beta-*",
-
-                "System.Globalization": "4.0.11-beta-*",
-
-                "System.Diagnostics.Debug": "4.0.11-beta-*",
-                "System.Diagnostics.Tools": "4.0.1-beta-*",
-                "System.Diagnostics.Tracing": "4.0.21-beta-*",
-
-                "System.Threading": "4.0.11-beta-*"
+                "System.Collections.Concurrent": "4.0.11-*",
+                "System.Dynamic.Runtime": "4.0.11-*",
+                "System.Reflection.Emit": "4.0.1-*",
+                "System.Reflection.TypeExtensions": "4.1.0-*",
+                "System.Linq.Expressions": "4.0.11-*",
+                "System.Linq.Queryable": "4.0.1-*"
             }
         },
         "sl5": {

--- a/src/System.Linq.Dynamic.Core/project.json
+++ b/src/System.Linq.Dynamic.Core/project.json
@@ -13,68 +13,51 @@
     "compilationOptions": {
     },
 
+    "dependencies": {
+        "JetBrains.Annotations": {
+            "version": "10.1.4",
+            "type": "build"
+        }
+    },
+
     "frameworks": {
         "net35": {
             "frameworkAssemblies": {
             },
             "dependencies": {
-                "JetBrains.Annotations": "10.1.4",
                 "NetLegacySupport.ConcurrentDictionary": "1.1.0"
             }
         },
         "net40": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "net45": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "net451": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "net452": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "net461": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "dnx451": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "dnx452": {
-            "dependencies": {
-                "JetBrains.Annotations": "10.1.4"
-            },
             "frameworkAssemblies": {
             }
         },
         "dnxcore5": {
             "dependencies": {
-                "JetBrains.Annotations": "10.1.4",
-
                 "Microsoft.CSharp": "4.0.1-beta-*",
 
                 "System.Collections.Concurrent": "4.0.11-beta-*",
@@ -107,8 +90,6 @@
         },
         "dotnet54": {
             "dependencies": {
-                "JetBrains.Annotations": "10.1.4",
-
                 "Microsoft.CSharp": "4.0.1-beta-*",
 
                 "System.Collections.Concurrent": "4.0.11-beta-*",
@@ -144,7 +125,6 @@
                 "define": [ "SILVERLIGHT" ]
             },
             "dependencies": {
-                "JetBrains.Annotations": "10.1.4",
                 "Portable.ConcurrentDictionary": "1.0.1"
             },
             "frameworkAssemblies": {

--- a/web/DynamicLinqWebDocs/DynamicLinqWebDocs.csproj
+++ b/web/DynamicLinqWebDocs/DynamicLinqWebDocs.csproj
@@ -43,18 +43,18 @@
   <ItemGroup>
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
+      <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="MarkdownSharp">
-      <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
+      <HintPath>..\..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SimpleMvcSitemap, Version=2.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SimpleMvcSitemap.2.3.1\lib\net45\SimpleMvcSitemap.dll</HintPath>
+      <HintPath>..\..\packages\SimpleMvcSitemap.2.3.1\lib\net45\SimpleMvcSitemap.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -68,34 +68,34 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
@@ -104,7 +104,7 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>
@@ -113,7 +113,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
+      <HintPath>..\..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
1. Fix build for `DynamicLinqWebDocs`.
2. Dynamic load `System.Data.Entity`or`EntityFramework` as predefined types if it is found.
3. `SqlFunctions`, `SqlSpatialFunctions` and `DbFunctions`(EF6) is also supported.
4. Allow to overwrite keywords.
5. Allow to use FullName of type(***May not works***).
6. `System.Data.Entity` is always here, so overwrite short name of it with `EntityFramework` if `EntityFramework` is found. If `System.Data.Entity` is needed, FullName of type can be used(***FullName may not works as 5***).
7. Remove usless dependences(`System.Data.Entity`,`JetBrains.Annotations` and many others for dnxcore5 and dotnet54).