### PR TITLE
Fix - when method has object parameter and ValueType value is passed into this method, result is exception in System.Dynamic.Utils.ExpressionUtils.ValidateOneArgument.

### DIFF
--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -863,5 +863,80 @@ namespace System.Linq.Dynamic.Core.Tests
 
             Assert.Equal(expected, result);
         }
+
+        [Fact]
+        public void ExpressionTests_MethodCall_ValueTypeToValueTypeParameter()
+        {
+            //Arrange
+            var list = new int[] { 0, 1, 2, 3, 4 };
+
+            //Act
+            var methods = new Methods();
+            var expectedResult = list.Where(x => methods.Method1(x));
+            var result = list.AsQueryable().Where("@0.Method1(it)", methods);
+
+            //Assert
+            Assert.Equal(expectedResult.Count(), result.Count());
+        }
+
+        [Fact]
+        public void ExpressionTests_MethodCall_ValueTypeToObjectParameterWithCast()
+        {
+            //Arrange
+            var list = new int[] { 0, 1, 2, 3, 4 };
+
+            //Act
+            var methods = new Methods();
+            var expectedResult = list.Where(x => methods.Method2(x));
+            var result = list.AsQueryable().Where("@0.Method2(object(it))", methods);
+
+            //Assert
+            Assert.Equal(expectedResult.Count(), result.Count());
+        }
+
+        [Fact]
+        public void ExpressionTests_MethodCall_ValueTypeToObjectParameterWithoutCast()
+        {
+            //Arrange
+            var list = new int[] { 0, 1, 2, 3, 4 };
+
+            //Act
+            var methods = new Methods();
+            var expectedResult = list.Where(x => methods.Method2(x));
+            var result = list.AsQueryable().Where("@0.Method2(it)", methods);
+
+            //Assert
+            Assert.Equal(expectedResult.Count(), result.Count());
+        }
+
+        [Fact]
+        public void ExpressionTests_MethodCall_NullableValueTypeToObjectParameter()
+        {
+            //Arrange
+            var list = new int?[] { 0, 1, 2, 3, 4, null };
+
+            //Act
+            var methods = new Methods();
+            var expectedResult = list.Where(x => methods.Method2(x));
+            var result = list.AsQueryable().Where("@0.Method2(it)", methods);
+
+            //Assert
+            Assert.Equal(expectedResult.Count(), result.Count());
+        }
+
+        [Fact]
+        public void ExpressionTests_MethodCall_ReferenceTypeToObjectParameter()
+        {
+            //Arrange
+            var list = new int[] { 0, 1, 2, 3, 4 }.Select(value => new Methods.Item { Value = value }).ToArray();
+
+            //Act
+            var methods = new Methods();
+            var expectedResult = list.Where(x => methods.Method3(x));
+            var result = list.AsQueryable().Where("@0.Method3(it)", methods);
+
+            //Assert
+            Assert.Equal(expectedResult.Count(), result.Count());
+        }
     }
 }

--- a/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/Methods.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/Methods.cs
@@ -1,0 +1,26 @@
+﻿namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
+{
+    public class Methods
+    {
+        public bool Method1(int value)
+        {
+            return value == 1;
+        }
+
+        public bool Method2(object value)
+        {
+            return value != null && (int)value == 1;
+        }
+
+        public bool Method3(object value)
+        {
+            Item item = value as Item;
+            return item != null && item.Value == 1;
+        }
+
+        public class Item
+        {
+            public int Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Tests included.
Without changes in ExpressionParser next two tests failed:
ExpressionTests_MethodCall_ValueTypeToObjectParameterWithoutCast,
ExpressionTests_MethodCall_NullableValueTypeToObjectParameter