### PR TITLE
Feature: Add support for querying a IQueryable<dynamic>

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 os: Visual Studio 2017
 
-version: 1.0.7.{build}
+version: 1.0.8.{build}
 
 configuration:
 - Debug

--- a/src-console/ConsoleAppEF1.1/Program.cs
+++ b/src-console/ConsoleAppEF1.1/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
 using System.Linq.Dynamic.Core;
 using Newtonsoft.Json;
 

--- a/src-console/ConsoleAppEF2.0/Program.cs
+++ b/src-console/ConsoleAppEF2.0/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Linq.Dynamic.Core.CustomTypeProviders;
@@ -25,9 +26,32 @@ namespace ConsoleAppEF2
             }
         }
 
+        private static IEnumerable<dynamic> GetEnumerable()
+        {
+            var random = new Random((int)DateTime.Now.Ticks);
+
+            return Enumerable.Range(0, 10).Select(i => new
+            {
+                Id = i,
+                Value = random.Next(),
+            });
+        }
+
         static void Main(string[] args)
         {
-            var all = new 
+            IQueryable<dynamic> qry = GetEnumerable().AsQueryable();
+
+            var result = qry.Select("it").OrderBy("Value");
+            try
+            {
+                Console.WriteLine("result {0}", JsonConvert.SerializeObject(result, Formatting.Indented));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
+            var all = new
             {
                 test1 = new List<int> { 1, 2, 3 }.ToDynamicList(typeof(int)),
                 test2 = new List<dynamic> { 4, 5, 6 }.ToDynamicList(typeof(int)),

--- a/src/System.Linq.Dynamic.Core/DynamicClass.net35.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicClass.net35.cs
@@ -1,0 +1,58 @@
+﻿#if NET35
+namespace System.Linq.Dynamic.Core
+{
+    /// <summary>
+    /// Provides a base class for dynamic objects for Net 3.5
+    /// </summary>
+    public abstract class DynamicClass
+    {
+        /// <summary>
+        /// Gets the dynamic property by name.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns>T</returns>
+        public T GetDynamicPropertyValue<T>(string propertyName)
+        {
+            var type = GetType();
+            var propInfo = type.GetProperty(propertyName);
+
+            return (T)propInfo.GetValue(this, null);
+        }
+
+        /// <summary>
+        /// Gets the dynamic property value by name.
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns>value</returns>
+        public object GetDynamicPropertyValue(string propertyName)
+        {
+            return GetDynamicPropertyValue<object>(propertyName);
+        }
+
+        /// <summary>
+        /// Sets the dynamic property value by name.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="value">The value.</param>
+        public void SetDynamicPropertyValue<T>(string propertyName, T value)
+        {
+            var type = GetType();
+            var propInfo = type.GetProperty(propertyName);
+
+            propInfo.SetValue(this, value, null);
+        }
+
+        /// <summary>
+        /// Sets the dynamic property value by name.
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="value">The value.</param>
+        public void SetDynamicPropertyValue(string propertyName, object value)
+        {
+            SetDynamicPropertyValue<object>(propertyName, value);
+        }
+    }
+}
+#endif

--- a/src/System.Linq.Dynamic.Core/DynamicGetMemberBinder.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicGetMemberBinder.cs
@@ -1,6 +1,4 @@
-﻿// From SqlLinq by dkackman
-// https://github.com/dkackman/SqlLinq/blob/210b594e37f14061424397368ed750ce547c21e7/License.md
-
+﻿#if !NET35
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq.Expressions;
@@ -8,25 +6,29 @@ using System.Reflection;
 
 namespace System.Linq.Dynamic.Core
 {
+    /// <summary>
+    /// Based on From SqlLinq by dkackman. https://github.com/dkackman/SqlLinq/blob/210b594e37f14061424397368ed750ce547c21e7/License.md
+    /// </summary>
+    /// <seealso cref="GetMemberBinder" />
     internal class DynamicGetMemberBinder : GetMemberBinder
     {
-        private readonly static PropertyInfo _indexer = typeof(IDictionary<string, object>).GetProperty("Item");
+        private static readonly PropertyInfo Indexer = typeof(IDictionary<string, object>).GetProperty("Item");
 
         public DynamicGetMemberBinder(string name)
             : base(name, true)
         {
-
         }
 
         public override DynamicMetaObject FallbackGetMember(DynamicMetaObject target, DynamicMetaObject errorSuggestion)
         {
-            var d = target.Value as IDictionary<string, object>;
-            if (d == null)
+            IDictionary<string, object> dictionary = target.Value as IDictionary<string, object>;
+            if (dictionary == null)
             {
                 throw new InvalidOperationException("Target object is not an ExpandoObject");
             }
 
-            return DynamicMetaObject.Create(d, Expression.MakeIndex(Expression.Constant(d), _indexer, new Expression[] { Expression.Constant(this.Name) }));
+            return DynamicMetaObject.Create(dictionary, Expression.MakeIndex(Expression.Constant(dictionary), Indexer, new Expression[] { Expression.Constant(Name) }));
         }
     }
 }
+#endif

--- a/src/System.Linq.Dynamic.Core/DynamicGetMemberBinder.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicGetMemberBinder.cs
@@ -1,0 +1,32 @@
+﻿// From SqlLinq by dkackman
+// https://github.com/dkackman/SqlLinq/blob/210b594e37f14061424397368ed750ce547c21e7/License.md
+
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace System.Linq.Dynamic.Core
+{
+    internal class DynamicGetMemberBinder : GetMemberBinder
+    {
+        private readonly static PropertyInfo _indexer = typeof(IDictionary<string, object>).GetProperty("Item");
+
+        public DynamicGetMemberBinder(string name)
+            : base(name, true)
+        {
+
+        }
+
+        public override DynamicMetaObject FallbackGetMember(DynamicMetaObject target, DynamicMetaObject errorSuggestion)
+        {
+            var d = target.Value as IDictionary<string, object>;
+            if (d == null)
+            {
+                throw new InvalidOperationException("Target object is not an ExpandoObject");
+            }
+
+            return DynamicMetaObject.Create(d, Expression.MakeIndex(Expression.Constant(d), _indexer, new Expression[] { Expression.Constant(this.Name) }));
+        }
+    }
+}

--- a/src/System.Linq.Dynamic.Core/DynamicQueryableExtensions.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicQueryableExtensions.cs
@@ -477,7 +477,7 @@ namespace System.Linq.Dynamic.Core
             LambdaExpression elementLambda = DynamicExpressionParser.ParseLambda(createParameterCtor, source.ElementType, null, resultSelector, args);
 
             var optimized = OptimizeExpression(Expression.Call(
-                typeof(Queryable), "GroupBy",
+                typeof(Queryable), nameof(Queryable.GroupBy),
                 new[] { source.ElementType, keyLambda.Body.Type, elementLambda.Body.Type },
                 source.Expression, Expression.Quote(keyLambda), Expression.Quote(elementLambda)));
 
@@ -635,7 +635,7 @@ namespace System.Linq.Dynamic.Core
             LambdaExpression resultSelectorLambda = DynamicExpressionParser.ParseLambda(createParameterCtor, parameters, null, resultSelector, args);
 
             return outer.Provider.CreateQuery(Expression.Call(
-                typeof(Queryable), "GroupJoin",
+                typeof(Queryable), nameof(Queryable.GroupJoin),
                 new[] { outer.ElementType, innerType, outerSelectorLambda.Body.Type, resultSelectorLambda.Body.Type },
                 outer.Expression,
                 Expression.Constant(inner),
@@ -1146,9 +1146,13 @@ namespace System.Linq.Dynamic.Core
                 // SelectMany assumes that lambda.Body.Type is a generic type and throws an exception on
                 // lambda.Body.Type.GetGenericArguments()[0] when used over an array as GetGenericArguments() returns an empty array.
                 if (lambda.Body.Type.IsArray)
+                {
                     resultType = lambda.Body.Type.GetElementType();
+                }
                 else
+                {
                     resultType = lambda.Body.Type.GetGenericArguments()[0];
+                }
             }
 
             //we have to adjust to lambda to return an IEnumerable<T> instead of whatever the actual property is.
@@ -1158,7 +1162,7 @@ namespace System.Linq.Dynamic.Core
             lambda = Expression.Lambda(delegateType, lambda.Body, lambda.Parameters);
 
             var optimized = OptimizeExpression(Expression.Call(
-                typeof(Queryable), "SelectMany",
+                typeof(Queryable), nameof(Queryable.SelectMany),
                 new[] { source.ElementType, resultType },
                 source.Expression, Expression.Quote(lambda))
             );
@@ -1196,7 +1200,7 @@ namespace System.Linq.Dynamic.Core
             lambda = Expression.Lambda(delegateType, lambda.Body, lambda.Parameters);
 
             var optimized = OptimizeExpression(Expression.Call(
-                typeof(Queryable), "SelectMany",
+                typeof(Queryable), nameof(Queryable.SelectMany),
                 new[] { source.ElementType, typeof(TResult) },
                 source.Expression, Expression.Quote(lambda))
             );
@@ -1285,7 +1289,7 @@ namespace System.Linq.Dynamic.Core
             Type resultLambdaResultType = resultSelectLambda.Body.Type;
 
             var optimized = OptimizeExpression(Expression.Call(
-                typeof(Queryable), "SelectMany",
+                typeof(Queryable), nameof(Queryable.SelectMany),
                 new[] { source.ElementType, sourceLambdaResultType, resultLambdaResultType },
                 source.Expression, Expression.Quote(sourceSelectLambda), Expression.Quote(resultSelectLambda))
             );
@@ -1309,7 +1313,7 @@ namespace System.Linq.Dynamic.Core
         {
             Check.NotNull(source, nameof(source));
 
-            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), "Single", new[] { source.ElementType }, source.Expression));
+            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), nameof(Queryable.Single), new[] { source.ElementType }, source.Expression));
             return source.Provider.Execute(optimized);
         }
 
@@ -1370,7 +1374,7 @@ namespace System.Linq.Dynamic.Core
         {
             Check.NotNull(source, nameof(source));
 
-            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), "SingleOrDefault", new[] { source.ElementType }, source.Expression));
+            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), nameof(Queryable.SingleOrDefault), new[] { source.ElementType }, source.Expression));
             return source.Provider.Execute(optimized);
         }
 
@@ -1478,7 +1482,7 @@ namespace System.Linq.Dynamic.Core
         {
             Check.NotNull(source, nameof(source));
 
-            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), "Sum", null, source.Expression));
+            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), nameof(Queryable.Sum), null, source.Expression));
             return source.Provider.Execute(optimized);
         }
         #endregion Sum
@@ -1670,7 +1674,7 @@ namespace System.Linq.Dynamic.Core
             Check.NotNull(source, nameof(source));
             Check.NotNull(lambda, nameof(lambda));
 
-            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), "Where", new[] { source.ElementType }, source.Expression, Expression.Quote(lambda)));
+            var optimized = OptimizeExpression(Expression.Call(typeof(Queryable), nameof(Queryable.Where), new[] { source.ElementType }, source.Expression, Expression.Quote(lambda)));
             return source.Provider.CreateQuery(optimized);
         }
         #endregion

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -1174,33 +1174,33 @@ namespace System.Linq.Dynamic.Core.Parser
                 if (_parsingConfig != null && _parsingConfig.UseDynamicObjectClassForAnonymousTypes)
                 {
 #endif
-                    type = typeof(DynamicClass);
-                    Type typeForKeyValuePair = typeof(KeyValuePair<string, object>);
+                type = typeof(DynamicClass);
+                Type typeForKeyValuePair = typeof(KeyValuePair<string, object>);
 #if NET35 || NET40
                     ConstructorInfo constructorForKeyValuePair = typeForKeyValuePair.GetConstructors().First();
 #else
-                    ConstructorInfo constructorForKeyValuePair = typeForKeyValuePair.GetTypeInfo().DeclaredConstructors.First();
+                ConstructorInfo constructorForKeyValuePair = typeForKeyValuePair.GetTypeInfo().DeclaredConstructors.First();
 #endif
-                    var arrayIndexParams = new List<Expression>();
-                    for (int i = 0; i < expressions.Count; i++)
-                    {
-                        // Just convert the expression always to an object expression.
-                        UnaryExpression boxingExpression = Expression.Convert(expressions[i], typeof(object));
-                        NewExpression parameter = Expression.New(constructorForKeyValuePair, (Expression)Expression.Constant(properties[i].Name), boxingExpression);
+                var arrayIndexParams = new List<Expression>();
+                for (int i = 0; i < expressions.Count; i++)
+                {
+                    // Just convert the expression always to an object expression.
+                    UnaryExpression boxingExpression = Expression.Convert(expressions[i], typeof(object));
+                    NewExpression parameter = Expression.New(constructorForKeyValuePair, (Expression)Expression.Constant(properties[i].Name), boxingExpression);
 
-                        arrayIndexParams.Add(parameter);
-                    }
+                    arrayIndexParams.Add(parameter);
+                }
 
-                    // Create an expression tree that represents creating and initializing a one-dimensional array of type KeyValuePair<string, object>.
-                    NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(KeyValuePair<string, object>), arrayIndexParams);
+                // Create an expression tree that represents creating and initializing a one-dimensional array of type KeyValuePair<string, object>.
+                NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(KeyValuePair<string, object>), arrayIndexParams);
 
-                    // Get the "public DynamicClass(KeyValuePair<string, object>[] propertylist)" constructor
+                // Get the "public DynamicClass(KeyValuePair<string, object>[] propertylist)" constructor
 #if NET35 || NET40
                     ConstructorInfo constructor = type.GetConstructors().First();
 #else
-                    ConstructorInfo constructor = type.GetTypeInfo().DeclaredConstructors.First();
+                ConstructorInfo constructor = type.GetTypeInfo().DeclaredConstructors.First();
 #endif
-                    return Expression.New(constructor, newArrayExpression);
+                return Expression.New(constructor, newArrayExpression);
 #if !UAP10_0
                 }
 
@@ -1226,6 +1226,7 @@ namespace System.Linq.Dynamic.Core.Parser
             {
                 bindings[i] = Expression.Bind(type.GetProperty(properties[i].Name), expressions[i]);
             }
+
             return Expression.MemberInit(Expression.New(type), bindings);
         }
 
@@ -1406,10 +1407,10 @@ namespace System.Linq.Dynamic.Core.Parser
                 return Expression.Constant(@enum);
             }
 
-#if NETFX_CORE
-            if (type == typeof(DynamicObjectClass))
+#if UAP10_0 || NETSTANDARD1_3
+            if (type == typeof(DynamicClass))
             {
-                return Expression.MakeIndex(instance, typeof(DynamicObjectClass).GetProperty("Item"), new[] { Expression.Constant(id) });
+                return Expression.MakeIndex(instance, typeof(DynamicClass).GetProperty("Item"), new[] { Expression.Constant(id) });
             }
 #endif
             MemberInfo member = FindPropertyOrField(type, id, instance == null);

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -349,9 +349,9 @@ namespace System.Linq.Dynamic.Core.Parser
 
                     var args = new[] { left };
 
-                    if (MethodFinder.FindMethod(typeof(IEnumerableSignatures), "Contains", false, args, out MethodBase containsSignature) != 1)
+                    if (MethodFinder.FindMethod(typeof(IEnumerableSignatures), nameof(IEnumerableSignatures.Contains), false, args, out MethodBase containsSignature) != 1)
                     {
-                        throw ParseError(op.Pos, Res.NoApplicableAggregate, "Contains");
+                        throw ParseError(op.Pos, Res.NoApplicableAggregate, nameof(IEnumerableSignatures.Contains));
                     }
 
                     var typeArgs = new[] { left.Type };
@@ -1153,14 +1153,10 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (newType != null)
             {
-                return Expression.NewArrayInit(
-                    newType,
-                    expressions.Select(expression => ExpressionPromoter.Promote(expression, newType, true, true)));
+                return Expression.NewArrayInit(newType, expressions.Select(expression => ExpressionPromoter.Promote(expression, newType, true, true)));
             }
 
-            return Expression.NewArrayInit(
-                expressions.All(expression => expression.Type == expressions[0].Type) ? expressions[0].Type : typeof(object),
-                expressions);
+            return Expression.NewArrayInit(expressions.All(expression => expression.Type == expressions[0].Type) ? expressions[0].Type : typeof(object), expressions);
         }
 
         private Expression CreateNewExpression(List<DynamicProperty> properties, List<Expression> expressions, Type newType)
@@ -1174,33 +1170,33 @@ namespace System.Linq.Dynamic.Core.Parser
                 if (_parsingConfig != null && _parsingConfig.UseDynamicObjectClassForAnonymousTypes)
                 {
 #endif
-                type = typeof(DynamicClass);
-                Type typeForKeyValuePair = typeof(KeyValuePair<string, object>);
+                    type = typeof(DynamicClass);
+                    Type typeForKeyValuePair = typeof(KeyValuePair<string, object>);
 #if NET35 || NET40
                     ConstructorInfo constructorForKeyValuePair = typeForKeyValuePair.GetConstructors().First();
 #else
-                ConstructorInfo constructorForKeyValuePair = typeForKeyValuePair.GetTypeInfo().DeclaredConstructors.First();
+                    ConstructorInfo constructorForKeyValuePair = typeForKeyValuePair.GetTypeInfo().DeclaredConstructors.First();
 #endif
-                var arrayIndexParams = new List<Expression>();
-                for (int i = 0; i < expressions.Count; i++)
-                {
-                    // Just convert the expression always to an object expression.
-                    UnaryExpression boxingExpression = Expression.Convert(expressions[i], typeof(object));
-                    NewExpression parameter = Expression.New(constructorForKeyValuePair, (Expression)Expression.Constant(properties[i].Name), boxingExpression);
+                    var arrayIndexParams = new List<Expression>();
+                    for (int i = 0; i < expressions.Count; i++)
+                    {
+                        // Just convert the expression always to an object expression.
+                        UnaryExpression boxingExpression = Expression.Convert(expressions[i], typeof(object));
+                        NewExpression parameter = Expression.New(constructorForKeyValuePair, (Expression)Expression.Constant(properties[i].Name), boxingExpression);
 
-                    arrayIndexParams.Add(parameter);
-                }
+                        arrayIndexParams.Add(parameter);
+                    }
 
-                // Create an expression tree that represents creating and initializing a one-dimensional array of type KeyValuePair<string, object>.
-                NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(KeyValuePair<string, object>), arrayIndexParams);
+                    // Create an expression tree that represents creating and initializing a one-dimensional array of type KeyValuePair<string, object>.
+                    NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(KeyValuePair<string, object>), arrayIndexParams);
 
-                // Get the "public DynamicClass(KeyValuePair<string, object>[] propertylist)" constructor
+                    // Get the "public DynamicClass(KeyValuePair<string, object>[] propertylist)" constructor
 #if NET35 || NET40
                     ConstructorInfo constructor = type.GetConstructors().First();
 #else
-                ConstructorInfo constructor = type.GetTypeInfo().DeclaredConstructors.First();
+                    ConstructorInfo constructor = type.GetTypeInfo().DeclaredConstructors.First();
 #endif
-                return Expression.New(constructor, newArrayExpression);
+                    return Expression.New(constructor, newArrayExpression);
 #if !UAP10_0
                 }
 
@@ -1235,7 +1231,7 @@ namespace System.Linq.Dynamic.Core.Parser
             int errorPos = _textParser.CurrentToken.Pos;
             _textParser.NextToken();
             Expression[] args = ParseArgumentList();
-            if (MethodFinder.FindMethod(lambda.Type, "Invoke", false, args, out MethodBase _) != 1)
+            if (MethodFinder.FindMethod(lambda.Type, nameof(Expression.Invoke), false, args, out MethodBase _) != 1)
             {
                 throw ParseError(errorPos, Res.ArgsIncompatibleWithLambda);
             }

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1213,11 +1213,12 @@ namespace System.Linq.Dynamic.Core.Tests
             Assert.Equal(new[] { 100, 200 }, result.ToDynamicArray<int>());
         }
 
-        //[Fact]
-        //[Trait("Issue", "136")]
+#if !NETCOREAPP1_1
+        [Fact]
+        [Trait("Issue", "136")]
         public void ExpressionTests_Select_ExpandoObjects()
         {
-            //Arrange
+            // Arrange
             dynamic a = new ExpandoObject();
             a.Name = "a";
             a.BlogId = 100;
@@ -1227,12 +1228,13 @@ namespace System.Linq.Dynamic.Core.Tests
             var list = new List<dynamic> { a, b };
             IQueryable qry = list.AsQueryable();
 
+            // Act
             var result = qry.Select("it").Select("BlogId");
 
-            //Assert
+            // Assert
             Assert.Equal(new[] { 100, 200 }, result.ToDynamicArray<int>());
         }
-
+#endif
         [Fact]
         public void ExpressionTests_Shift()
         {

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1213,8 +1213,8 @@ namespace System.Linq.Dynamic.Core.Tests
             Assert.Equal(new[] { 100, 200 }, result.ToDynamicArray<int>());
         }
 
-        [Fact]
-        [Trait("Issue", "136")]
+        //[Fact]
+        //[Trait("Issue", "136")]
         public void ExpressionTests_Select_ExpandoObjects()
         {
             //Arrange

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1213,7 +1213,8 @@ namespace System.Linq.Dynamic.Core.Tests
             Assert.Equal(new[] { 100, 200 }, result.ToDynamicArray<int>());
         }
 
-        //[Fact]
+        [Fact]
+        [Trait("Issue", "136")]
         public void ExpressionTests_Select_ExpandoObjects()
         {
             //Arrange
@@ -1222,7 +1223,7 @@ namespace System.Linq.Dynamic.Core.Tests
             a.BlogId = 100;
             dynamic b = new ExpandoObject();
             b.Name = "b";
-            b.BlogId = 100;
+            b.BlogId = 200;
             var list = new List<dynamic> { a, b };
             IQueryable qry = list.AsQueryable();
 


### PR DESCRIPTION
Updates the `ParseMemberAccess` method so that if it can't get the property or field, it tries getting the member by a dynamic operation or by an indexer operation.

After a lot of searching I ended up on [this bit of code](https://github.com/dkackman/SqlLinq/blob/210b594e37f14061424397368ed750ce547c21e7/SqlLinq/SyntaxTree/ExpressionFactory.cs#L114) which seems to do the trick. The `ExpressionTests_Select_ExpandoObjects` test passes now.

Some notes:
- It will throw an exception only during evaluation if it can't find the specified member (and it is an `object` or has an indexer), currently a `InvalidOperationException` but perhaps introducing a new exception type is warranted?
- I'd still like to get `ExpressionTests_Select_DynamicObjects` but I'm not sure how I'll go.
- @StefH: Are you able to pull this and run all the tests on your machine? I was only able to get the solution building with a lot of hacking of projects and stripping out all platforms except net461.