### PR TITLE
Make ExpressionPromoter plugable

### DIFF
--- a/src/System.Linq.Dynamic.Core/CustomTypeProviders/IDynamicLinkCustomTypeProvider.cs
+++ b/src/System.Linq.Dynamic.Core/CustomTypeProviders/IDynamicLinkCustomTypeProvider.cs
@@ -20,6 +20,5 @@ namespace System.Linq.Dynamic.Core.CustomTypeProviders
         /// <param name="typeName">The typename to resolve.</param>
         /// <returns>A resolved <see cref="Type"/> or null when not found.</returns>
         Type ResolveType([NotNull] string typeName);
-
     }
 }

--- a/src/System.Linq.Dynamic.Core/CustomTypeProviders/IDynamicLinkCustomTypeProvider.cs
+++ b/src/System.Linq.Dynamic.Core/CustomTypeProviders/IDynamicLinkCustomTypeProvider.cs
@@ -20,5 +20,6 @@ namespace System.Linq.Dynamic.Core.CustomTypeProviders
         /// <param name="typeName">The typename to resolve.</param>
         /// <returns>A resolved <see cref="Type"/> or null when not found.</returns>
         Type ResolveType([NotNull] string typeName);
+
     }
 }

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -24,6 +24,7 @@ namespace System.Linq.Dynamic.Core.Parser
         static readonly string methodThenByDescending = nameof(Queryable.ThenByDescending);
 
         private readonly ParsingConfig _parsingConfig;
+        private readonly MethodFinder _methodFinder;
         private readonly KeywordsHelper _keywordsHelper;
         private readonly TextParser _textParser;
         private readonly Dictionary<string, object> _internals;
@@ -64,6 +65,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
             _keywordsHelper = new KeywordsHelper(_parsingConfig);
             _textParser = new TextParser(expression);
+            _methodFinder = new MethodFinder(_parsingConfig);
         }
 
         void ProcessParameters(ParameterExpression[] parameters)
@@ -130,7 +132,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (resultType != null)
             {
-                if ((expr = ExpressionPromoter.Promote(expr, resultType, true, false)) == null)
+                if ((expr = this._parsingConfig.ExpressionPromoter.Promote(expr, resultType, true, false)) == null)
                 {
                     throw ParseError(exprPos, Res.ExpressionTypeMismatch, TypeHelper.GetTypeName(resultType));
                 }
@@ -352,7 +354,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
                     var args = new[] { left };
 
-                    if (MethodFinder.FindMethod(typeof(IEnumerableSignatures), nameof(IEnumerableSignatures.Contains), false, args, out MethodBase containsSignature) != 1)
+                    if (this._methodFinder.FindMethod(typeof(IEnumerableSignatures), nameof(IEnumerableSignatures.Contains), false, args, out MethodBase containsSignature) != 1)
                     {
                         throw ParseError(op.Pos, Res.NoApplicableAggregate, nameof(IEnumerableSignatures.Contains));
                     }
@@ -469,11 +471,11 @@ namespace System.Linq.Dynamic.Core.Parser
                     if (left.Type != right.Type)
                     {
                         Expression e;
-                        if ((e = ExpressionPromoter.Promote(right, left.Type, true, false)) != null)
+                        if ((e = this._parsingConfig.ExpressionPromoter.Promote(right, left.Type, true, false)) != null)
                         {
                             right = e;
                         }
-                        else if ((e = ExpressionPromoter.Promote(left, right.Type, true, false)) != null)
+                        else if ((e = this._parsingConfig.ExpressionPromoter.Promote(left, right.Type, true, false)) != null)
                         {
                             left = e;
                         }
@@ -1059,8 +1061,8 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (expr1.Type != expr2.Type)
             {
-                Expression expr1As2 = expr2 != Constants.NullLiteral ? ExpressionPromoter.Promote(expr1, expr2.Type, true, false) : null;
-                Expression expr2As1 = expr1 != Constants.NullLiteral ? ExpressionPromoter.Promote(expr2, expr1.Type, true, false) : null;
+                Expression expr1As2 = expr2 != Constants.NullLiteral ? this._parsingConfig.ExpressionPromoter.Promote(expr1, expr2.Type, true, false) : null;
+                Expression expr2As1 = expr1 != Constants.NullLiteral ? this._parsingConfig.ExpressionPromoter.Promote(expr2, expr1.Type, true, false) : null;
                 if (expr1As2 != null && expr2As1 == null)
                 {
                     expr1 = expr1As2;
@@ -1200,7 +1202,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (newType != null)
             {
-                return Expression.NewArrayInit(newType, expressions.Select(expression => ExpressionPromoter.Promote(expression, newType, true, true)));
+                return Expression.NewArrayInit(newType, expressions.Select(expression => this._parsingConfig.ExpressionPromoter.Promote(expression, newType, true, true)));
             }
 
             return Expression.NewArrayInit(expressions.All(expression => expression.Type == expressions[0].Type) ? expressions[0].Type : typeof(object), expressions);
@@ -1270,7 +1272,7 @@ namespace System.Linq.Dynamic.Core.Parser
                     Type expressionType = expressions[i].Type;
 
                     // Promote from Type to Nullable Type if needed
-                    expressionsPromoted.Add(ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
+                    expressionsPromoted.Add(this._parsingConfig.ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
                 }
 
                 return Expression.New(ctor, expressionsPromoted, (IEnumerable<MemberInfo>)propertyInfos);
@@ -1284,7 +1286,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 Type expressionType = expressions[i].Type;
 
                 // Promote from Type to Nullable Type if needed
-                bindings[i] = Expression.Bind(property, ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
+                bindings[i] = Expression.Bind(property, this._parsingConfig.ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
             }
 
             return Expression.MemberInit(Expression.New(type), bindings);
@@ -1295,7 +1297,7 @@ namespace System.Linq.Dynamic.Core.Parser
             int errorPos = _textParser.CurrentToken.Pos;
             _textParser.NextToken();
             Expression[] args = ParseArgumentList();
-            if (MethodFinder.FindMethod(lambda.Type, nameof(Expression.Invoke), false, args, out MethodBase _) != 1)
+            if (this._methodFinder.FindMethod(lambda.Type, nameof(Expression.Invoke), false, args, out MethodBase _) != 1)
             {
                 throw ParseError(errorPos, Res.ArgsIncompatibleWithLambda);
             }
@@ -1336,7 +1338,7 @@ namespace System.Linq.Dynamic.Core.Parser
                     }
                 }
 
-                switch (MethodFinder.FindBestMethod(type.GetConstructors(), args, out MethodBase method))
+                switch (this._methodFinder.FindBestMethod(type.GetConstructors(), args, out MethodBase method))
                 {
                     case 0:
                         if (args.Length == 1)
@@ -1443,7 +1445,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 }
 
                 Expression[] args = ParseArgumentList();
-                switch (MethodFinder.FindMethod(type, id, instance == null, args, out MethodBase mb))
+                switch (this._methodFinder.FindMethod(type, id, instance == null, args, out MethodBase mb))
                 {
                     case 0:
                         throw ParseError(errorPos, Res.NoApplicableMethod, id, TypeHelper.GetTypeName(type));
@@ -1587,13 +1589,13 @@ namespace System.Linq.Dynamic.Core.Parser
             _it = outerIt;
             _parent = oldParent;
 
-            if (!MethodFinder.ContainsMethod(typeof(IEnumerableSignatures), methodName, false, args))
+            if (!this._methodFinder.ContainsMethod(typeof(IEnumerableSignatures), methodName, false, args))
             {
                 throw ParseError(errorPos, Res.NoApplicableAggregate, methodName);
             }
 
             Type callType = typeof(Enumerable);
-            if (isQueryable && MethodFinder.ContainsMethod(typeof(IQueryableSignatures), methodName, false, args))
+            if (isQueryable && this._methodFinder.ContainsMethod(typeof(IQueryableSignatures), methodName, false, args))
             {
                 callType = typeof(Queryable);
             }
@@ -1693,7 +1695,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 {
                     throw ParseError(errorPos, Res.CannotIndexMultiDimArray);
                 }
-                Expression index = ExpressionPromoter.Promote(args[0], typeof(int), true, false);
+                Expression index = this._parsingConfig.ExpressionPromoter.Promote(args[0], typeof(int), true, false);
 
                 if (index == null)
                 {
@@ -1703,7 +1705,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 return Expression.ArrayIndex(expr, index);
             }
 
-            switch (MethodFinder.FindIndexer(expr.Type, args, out var mb))
+            switch (this._methodFinder.FindIndexer(expr.Type, args, out var mb))
             {
                 case 0:
                     throw ParseError(errorPos, Res.NoApplicableIndexer,
@@ -1758,7 +1760,7 @@ namespace System.Linq.Dynamic.Core.Parser
         {
             Expression[] args = { expr };
 
-            if (!MethodFinder.ContainsMethod(signatures, "F", false, args))
+            if (!this._methodFinder.ContainsMethod(signatures, "F", false, args))
             {
                 throw IncompatibleOperandError(opName, expr, errorPos);
             }
@@ -1770,7 +1772,7 @@ namespace System.Linq.Dynamic.Core.Parser
         {
             Expression[] args = { left, right };
 
-            if (!MethodFinder.ContainsMethod(signatures, "F", false, args))
+            if (!this._methodFinder.ContainsMethod(signatures, "F", false, args))
             {
                 throw IncompatibleOperandsError(opName, left, right, errorPos);
             }

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -132,7 +132,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (resultType != null)
             {
-                if ((expr = this._parsingConfig.ExpressionPromoter.Promote(expr, resultType, true, false)) == null)
+                if ((expr = _parsingConfig.ExpressionPromoter.Promote(expr, resultType, true, false)) == null)
                 {
                     throw ParseError(exprPos, Res.ExpressionTypeMismatch, TypeHelper.GetTypeName(resultType));
                 }
@@ -354,7 +354,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
                     var args = new[] { left };
 
-                    if (this._methodFinder.FindMethod(typeof(IEnumerableSignatures), nameof(IEnumerableSignatures.Contains), false, args, out MethodBase containsSignature) != 1)
+                    if (_methodFinder.FindMethod(typeof(IEnumerableSignatures), nameof(IEnumerableSignatures.Contains), false, args, out MethodBase containsSignature) != 1)
                     {
                         throw ParseError(op.Pos, Res.NoApplicableAggregate, nameof(IEnumerableSignatures.Contains));
                     }
@@ -471,11 +471,11 @@ namespace System.Linq.Dynamic.Core.Parser
                     if (left.Type != right.Type)
                     {
                         Expression e;
-                        if ((e = this._parsingConfig.ExpressionPromoter.Promote(right, left.Type, true, false)) != null)
+                        if ((e = _parsingConfig.ExpressionPromoter.Promote(right, left.Type, true, false)) != null)
                         {
                             right = e;
                         }
-                        else if ((e = this._parsingConfig.ExpressionPromoter.Promote(left, right.Type, true, false)) != null)
+                        else if ((e = _parsingConfig.ExpressionPromoter.Promote(left, right.Type, true, false)) != null)
                         {
                             left = e;
                         }
@@ -1061,8 +1061,8 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (expr1.Type != expr2.Type)
             {
-                Expression expr1As2 = expr2 != Constants.NullLiteral ? this._parsingConfig.ExpressionPromoter.Promote(expr1, expr2.Type, true, false) : null;
-                Expression expr2As1 = expr1 != Constants.NullLiteral ? this._parsingConfig.ExpressionPromoter.Promote(expr2, expr1.Type, true, false) : null;
+                Expression expr1As2 = expr2 != Constants.NullLiteral ? _parsingConfig.ExpressionPromoter.Promote(expr1, expr2.Type, true, false) : null;
+                Expression expr2As1 = expr1 != Constants.NullLiteral ? _parsingConfig.ExpressionPromoter.Promote(expr2, expr1.Type, true, false) : null;
                 if (expr1As2 != null && expr2As1 == null)
                 {
                     expr1 = expr1As2;
@@ -1202,7 +1202,7 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (newType != null)
             {
-                return Expression.NewArrayInit(newType, expressions.Select(expression => this._parsingConfig.ExpressionPromoter.Promote(expression, newType, true, true)));
+                return Expression.NewArrayInit(newType, expressions.Select(expression => _parsingConfig.ExpressionPromoter.Promote(expression, newType, true, true)));
             }
 
             return Expression.NewArrayInit(expressions.All(expression => expression.Type == expressions[0].Type) ? expressions[0].Type : typeof(object), expressions);
@@ -1272,7 +1272,7 @@ namespace System.Linq.Dynamic.Core.Parser
                     Type expressionType = expressions[i].Type;
 
                     // Promote from Type to Nullable Type if needed
-                    expressionsPromoted.Add(this._parsingConfig.ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
+                    expressionsPromoted.Add(_parsingConfig.ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
                 }
 
                 return Expression.New(ctor, expressionsPromoted, (IEnumerable<MemberInfo>)propertyInfos);
@@ -1286,7 +1286,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 Type expressionType = expressions[i].Type;
 
                 // Promote from Type to Nullable Type if needed
-                bindings[i] = Expression.Bind(property, this._parsingConfig.ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
+                bindings[i] = Expression.Bind(property, _parsingConfig.ExpressionPromoter.Promote(expressions[i], propertyType, true, true));
             }
 
             return Expression.MemberInit(Expression.New(type), bindings);
@@ -1297,7 +1297,7 @@ namespace System.Linq.Dynamic.Core.Parser
             int errorPos = _textParser.CurrentToken.Pos;
             _textParser.NextToken();
             Expression[] args = ParseArgumentList();
-            if (this._methodFinder.FindMethod(lambda.Type, nameof(Expression.Invoke), false, args, out MethodBase _) != 1)
+            if (_methodFinder.FindMethod(lambda.Type, nameof(Expression.Invoke), false, args, out MethodBase _) != 1)
             {
                 throw ParseError(errorPos, Res.ArgsIncompatibleWithLambda);
             }
@@ -1338,7 +1338,7 @@ namespace System.Linq.Dynamic.Core.Parser
                     }
                 }
 
-                switch (this._methodFinder.FindBestMethod(type.GetConstructors(), args, out MethodBase method))
+                switch (_methodFinder.FindBestMethod(type.GetConstructors(), args, out MethodBase method))
                 {
                     case 0:
                         if (args.Length == 1)
@@ -1445,7 +1445,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 }
 
                 Expression[] args = ParseArgumentList();
-                switch (this._methodFinder.FindMethod(type, id, instance == null, args, out MethodBase mb))
+                switch (_methodFinder.FindMethod(type, id, instance == null, args, out MethodBase mb))
                 {
                     case 0:
                         throw ParseError(errorPos, Res.NoApplicableMethod, id, TypeHelper.GetTypeName(type));
@@ -1589,13 +1589,13 @@ namespace System.Linq.Dynamic.Core.Parser
             _it = outerIt;
             _parent = oldParent;
 
-            if (!this._methodFinder.ContainsMethod(typeof(IEnumerableSignatures), methodName, false, args))
+            if (!_methodFinder.ContainsMethod(typeof(IEnumerableSignatures), methodName, false, args))
             {
                 throw ParseError(errorPos, Res.NoApplicableAggregate, methodName);
             }
 
             Type callType = typeof(Enumerable);
-            if (isQueryable && this._methodFinder.ContainsMethod(typeof(IQueryableSignatures), methodName, false, args))
+            if (isQueryable && _methodFinder.ContainsMethod(typeof(IQueryableSignatures), methodName, false, args))
             {
                 callType = typeof(Queryable);
             }
@@ -1695,7 +1695,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 {
                     throw ParseError(errorPos, Res.CannotIndexMultiDimArray);
                 }
-                Expression index = this._parsingConfig.ExpressionPromoter.Promote(args[0], typeof(int), true, false);
+                Expression index = _parsingConfig.ExpressionPromoter.Promote(args[0], typeof(int), true, false);
 
                 if (index == null)
                 {
@@ -1705,7 +1705,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 return Expression.ArrayIndex(expr, index);
             }
 
-            switch (this._methodFinder.FindIndexer(expr.Type, args, out var mb))
+            switch (_methodFinder.FindIndexer(expr.Type, args, out var mb))
             {
                 case 0:
                     throw ParseError(errorPos, Res.NoApplicableIndexer,
@@ -1760,7 +1760,7 @@ namespace System.Linq.Dynamic.Core.Parser
         {
             Expression[] args = { expr };
 
-            if (!this._methodFinder.ContainsMethod(signatures, "F", false, args))
+            if (!_methodFinder.ContainsMethod(signatures, "F", false, args))
             {
                 throw IncompatibleOperandError(opName, expr, errorPos);
             }
@@ -1772,7 +1772,7 @@ namespace System.Linq.Dynamic.Core.Parser
         {
             Expression[] args = { left, right };
 
-            if (!this._methodFinder.ContainsMethod(signatures, "F", false, args))
+            if (!_methodFinder.ContainsMethod(signatures, "F", false, args))
             {
                 throw IncompatibleOperandsError(opName, left, right, errorPos);
             }

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace System.Linq.Dynamic.Core.Parser
 {
-    public class ExpressionPromoter : IExpressionPromoter
+    internal class ExpressionPromoter : IExpressionPromoter
     {
         /// <inheritdoc cref="IExpressionPromoter.Promote(Expression, Type, bool, bool)"/>
         public virtual Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 
 namespace System.Linq.Dynamic.Core.Parser
 {
-    internal static class ExpressionPromoter
+    internal class ExpressionPromoter : IExpressionPromoter
     {
-        public static Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)
+        public Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)
         {
             if (expr.Type == type)
             {

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
@@ -3,9 +3,10 @@ using System.Reflection;
 
 namespace System.Linq.Dynamic.Core.Parser
 {
-    internal class ExpressionPromoter : IExpressionPromoter
+    public class ExpressionPromoter : IExpressionPromoter
     {
-        public Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)
+        /// <inheritdoc cref="IExpressionPromoter.Promote(Expression, Type, bool, bool)"/>
+        public virtual Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)
         {
             if (expr.Type == type)
             {

--- a/src/System.Linq.Dynamic.Core/Parser/IExpressionPromoter.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/IExpressionPromoter.cs
@@ -3,17 +3,19 @@
 namespace System.Linq.Dynamic.Core.Parser
 {
     /// <summary>
-    /// Expression promoter is used whe matching
+    /// Expression promoter is used to promote object or value types
+    /// to their destination type when an automatic promotion is available
+    /// such as: int to int?
     /// </summary>
     public interface IExpressionPromoter
     {
         /// <summary>
         /// Promote an expression
         /// </summary>
-        /// <param name="expr">Source expression.</param>
-        /// <param name="type">Destionation data type to promote to.</param>
-        /// <param name="exact">If the match must be exact.</param>
-        /// <param name="convertExpr">Convert expression.</param>
+        /// <param name="expr">Source expression</param>
+        /// <param name="type">Destionation data type to promote</param>
+        /// <param name="exact">If the match must be exact</param>
+        /// <param name="convertExpr">Convert expression</param>
         /// <returns></returns>
         Expression Promote(Expression expr, Type type, bool exact, bool convertExpr);
     }

--- a/src/System.Linq.Dynamic.Core/Parser/IExpressionPromoter.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/IExpressionPromoter.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq.Expressions;
+
+namespace System.Linq.Dynamic.Core.Parser
+{
+    /// <summary>
+    /// Expression promoter is used whe matching
+    /// </summary>
+    public interface IExpressionPromoter
+    {
+        /// <summary>
+        /// Promote an expression
+        /// </summary>
+        /// <param name="expr">Source expression.</param>
+        /// <param name="type">Destionation data type to promote to.</param>
+        /// <param name="exact">If the match must be exact.</param>
+        /// <param name="convertExpr">Convert expression.</param>
+        /// <returns></returns>
+        Expression Promote(Expression expr, Type type, bool exact, bool convertExpr);
+    }
+}

--- a/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
@@ -6,9 +6,6 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
 {
     internal class MethodFinder
     {
-        /// <summary>
-        /// The parsing config
-        /// </summary>
         private ParsingConfig _parsingConfig;
 
         /// <summary>
@@ -17,7 +14,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
         /// <param name="parsingConfig"></param>
         public MethodFinder(ParsingConfig parsingConfig)
         {
-            this._parsingConfig = parsingConfig;
+            _parsingConfig = parsingConfig;
         }
 
         public bool ContainsMethod(Type type, string methodName, bool staticAccess, Expression[] args)

--- a/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
@@ -4,14 +4,28 @@ using System.Reflection;
 
 namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
 {
-    internal static class MethodFinder
+    internal class MethodFinder
     {
-        public static bool ContainsMethod(Type type, string methodName, bool staticAccess, Expression[] args)
+        /// <summary>
+        /// The parsing config
+        /// </summary>
+        private ParsingConfig _parsingConfig;
+
+        /// <summary>
+        /// Get an instance
+        /// </summary>
+        /// <param name="parsingConfig"></param>
+        public MethodFinder(ParsingConfig parsingConfig)
+        {
+            this._parsingConfig = parsingConfig;
+        }
+
+        public bool ContainsMethod(Type type, string methodName, bool staticAccess, Expression[] args)
         {
             return FindMethod(type, methodName, staticAccess, args, out var _) == 1;
         }
 
-        public static int FindMethod(Type type, string methodName, bool staticAccess, Expression[] args, out MethodBase method)
+        public int FindMethod(Type type, string methodName, bool staticAccess, Expression[] args, out MethodBase method)
         {
 #if !(NETFX_CORE || WINDOWS_APP || DOTNET5_1 || UAP10_0 || NETSTANDARD)
             BindingFlags flags = BindingFlags.Public | BindingFlags.DeclaredOnly | (staticAccess ? BindingFlags.Static : BindingFlags.Instance);
@@ -39,7 +53,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             return 0;
         }
 
-        public static int FindBestMethod(IEnumerable<MethodBase> methods, Expression[] args, out MethodBase method)
+        public int FindBestMethod(IEnumerable<MethodBase> methods, Expression[] args, out MethodBase method)
         {
             MethodData[] applicable = methods.
                 Select(m => new MethodData { MethodBase = m, Parameters = m.GetParameters() }).
@@ -73,7 +87,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             return applicable.Length;
         }
 
-        public static int FindIndexer(Type type, Expression[] args, out MethodBase method)
+        public int FindIndexer(Type type, Expression[] args, out MethodBase method)
         {
             foreach (Type t in SelfAndBaseTypes(type))
             {
@@ -99,7 +113,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             return 0;
         }
 
-        static bool IsApplicable(MethodData method, Expression[] args)
+        bool IsApplicable(MethodData method, Expression[] args)
         {
             if (method.Parameters.Length != args.Length)
             {
@@ -115,7 +129,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
                     return false;
                 }
 
-                Expression promoted = ExpressionPromoter.Promote(args[i], pi.ParameterType, false, method.MethodBase.DeclaringType != typeof(IEnumerableSignatures));
+                Expression promoted = this._parsingConfig.ExpressionPromoter.Promote(args[i], pi.ParameterType, false, method.MethodBase.DeclaringType != typeof(IEnumerableSignatures));
                 if (promoted == null)
                 {
                     return false;
@@ -126,7 +140,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             return true;
         }
 
-        static bool IsBetterThan(Expression[] args, MethodData first, MethodData second)
+        bool IsBetterThan(Expression[] args, MethodData first, MethodData second)
         {
             bool better = false;
             for (int i = 0; i < args.Length; i++)
@@ -158,7 +172,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
         // Return "First" if s -> t1 is a better conversion than s -> t2
         // Return "Second" if s -> t2 is a better conversion than s -> t1
         // Return "Both" if neither conversion is better
-        static CompareConversionType CompareConversions(Type source, Type first, Type second)
+        CompareConversionType CompareConversions(Type source, Type first, Type second)
         {
             if (first == second)
             {
@@ -197,7 +211,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             return CompareConversionType.Both;
         }
 
-        static IEnumerable<Type> SelfAndBaseTypes(Type type)
+        IEnumerable<Type> SelfAndBaseTypes(Type type)
         {
             if (type.GetTypeInfo().IsInterface)
             {
@@ -208,7 +222,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             return SelfAndBaseClasses(type);
         }
 
-        static IEnumerable<Type> SelfAndBaseClasses(Type type)
+        IEnumerable<Type> SelfAndBaseClasses(Type type)
         {
             while (type != null)
             {
@@ -217,7 +231,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             }
         }
 
-        static void AddInterface(List<Type> types, Type type)
+        void AddInterface(List<Type> types, Type type)
         {
             if (!types.Contains(type))
             {

--- a/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
@@ -6,7 +6,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
 {
     internal class MethodFinder
     {
-        private ParsingConfig _parsingConfig;
+        private readonly ParsingConfig _parsingConfig;
 
         /// <summary>
         /// Get an instance

--- a/src/System.Linq.Dynamic.Core/ParsingConfig.cs
+++ b/src/System.Linq.Dynamic.Core/ParsingConfig.cs
@@ -21,14 +21,8 @@ namespace System.Linq.Dynamic.Core
             EvaluateGroupByAtDatabase = true
         };
 
-        /// <summary>
-        /// The custom type provider.
-        /// </summary>
         private IDynamicLinkCustomTypeProvider _customTypeProvider;
 
-        /// <summary>
-        /// The expression promoter.
-        /// </summary>
         private IExpressionPromoter _expressionPromoter;
 
         /// <summary>

--- a/src/System.Linq.Dynamic.Core/ParsingConfig.cs
+++ b/src/System.Linq.Dynamic.Core/ParsingConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Dynamic.Core.CustomTypeProviders;
+using System.Linq.Dynamic.Core.Parser;
 
 namespace System.Linq.Dynamic.Core
 {
@@ -20,7 +21,15 @@ namespace System.Linq.Dynamic.Core
             EvaluateGroupByAtDatabase = true
         };
 
+        /// <summary>
+        /// The custom type provider.
+        /// </summary>
         private IDynamicLinkCustomTypeProvider _customTypeProvider;
+
+        /// <summary>
+        /// The expression promoter.
+        /// </summary>
+        private IExpressionPromoter _expressionPromoter;
 
         /// <summary>
         /// Gets or sets the <see cref="IDynamicLinkCustomTypeProvider"/>.
@@ -42,6 +51,25 @@ namespace System.Linq.Dynamic.Core
                 if (_customTypeProvider != value)
                 {
                     _customTypeProvider = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IExpressionPromoter"/>.
+        /// </summary>
+        public IExpressionPromoter ExpressionPromoter
+        {
+            get
+            {
+                return _expressionPromoter ?? (_expressionPromoter = new ExpressionPromoter());
+            }
+
+            set
+            {
+                if (_expressionPromoter != value)
+                {
+                    _expressionPromoter = value;
                 }
             }
         }

--- a/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
+++ b/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
@@ -34,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
@@ -58,20 +61,30 @@
     <Reference Include="MongoDB.Driver.Core, Version=2.4.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MongoDB.Driver.Core.2.4.4\lib\net45\MongoDB.Driver.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NFluent, Version=1.4.0.1, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NFluent.2.0.0-alpha\lib\net40\NFluent.dll</HintPath>
+    <Reference Include="NFluent, Version=2.1.1.107, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NFluent.2.1.1\lib\net45\NFluent.dll</HintPath>
     </Reference>
     <Reference Include="QueryInterceptor.Core, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\QueryInterceptor.Core.1.0.5.0\lib\net452\QueryInterceptor.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
+++ b/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
@@ -189,6 +189,9 @@
     <Compile Include="..\System.Linq.Dynamic.Core.Tests\Entities\User.cs">
       <Link>Entities\User.cs</Link>
     </Compile>
+    <Compile Include="..\System.Linq.Dynamic.Core.Tests\ExpressionPromoterTests.cs">
+      <Link>ExpressionPromoterTests.cs</Link>
+    </Compile>
     <Compile Include="..\System.Linq.Dynamic.Core.Tests\ExpressionTests.cs">
       <Link>ExpressionTests.cs</Link>
     </Compile>

--- a/test/EntityFramework.DynamicLinq.Tests.net452/packages.config
+++ b/test/EntityFramework.DynamicLinq.Tests.net452/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Linq.PropertyTranslator.Core" version="1.0.3.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
@@ -7,10 +8,13 @@
   <package id="MongoDB.Bson" version="2.4.4" targetFramework="net452" />
   <package id="MongoDB.Driver" version="2.4.4" targetFramework="net452" />
   <package id="MongoDB.Driver.Core" version="2.4.4" targetFramework="net452" />
+  <package id="Moq" version="4.10.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NFluent" version="2.0.0-alpha" targetFramework="net452" />
+  <package id="NFluent" version="2.1.1" targetFramework="net452" />
   <package id="QueryInterceptor.Core" version="1.0.5.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
   <package id="xunit" version="2.3.1" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />

--- a/test/EntityFramework.DynamicLinq.Tests/EntityFramework.DynamicLinq.Tests.csproj
+++ b/test/EntityFramework.DynamicLinq.Tests/EntityFramework.DynamicLinq.Tests.csproj
@@ -1,51 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Authors>Stef Heyenrath</Authors>
-    <TargetFramework>net461</TargetFramework>
-    <DefineConstants>EF</DefineConstants>
-    <AssemblyName>EntityFramework.DynamicLinq.Tests</AssemblyName>
-    <PackageId>EntityFramework.DynamicLinq.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <ProjectGuid>{BF97CB1B-5043-4256-8F42-CF3A4F3863BE}</ProjectGuid>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Authors>Stef Heyenrath</Authors>
+        <TargetFramework>net461</TargetFramework>
+        <DefineConstants>EF</DefineConstants>
+        <AssemblyName>EntityFramework.DynamicLinq.Tests</AssemblyName>
+        <PackageId>EntityFramework.DynamicLinq.Tests</PackageId>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <ProjectGuid>{BF97CB1B-5043-4256-8F42-CF3A4F3863BE}</ProjectGuid>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\QueryableTests.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\QueryableTests.*.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\EntitiesTests.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\EntitiesTests.*.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\Entities\*.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\TestHelpers\*.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\*.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\*\*.cs" />
-    <Compile Include="..\System.Linq.Dynamic.Core.Tests\D*.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\QueryableTests.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\QueryableTests.*.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\EntitiesTests.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\EntitiesTests.*.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\Entities\*.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\TestHelpers\*.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\*.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\*\*.cs" />
+        <Compile Include="..\System.Linq.Dynamic.Core.Tests\D*.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\System.Linq.Dynamic.Core\System.Linq.Dynamic.Core.csproj" />
-    <ProjectReference Include="..\..\src\EntityFramework.DynamicLinq\EntityFramework.DynamicLinq.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\System.Linq.Dynamic.Core\System.Linq.Dynamic.Core.csproj" />
+        <ProjectReference Include="..\..\src\EntityFramework.DynamicLinq\EntityFramework.DynamicLinq.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Linq.PropertyTranslator.Core" Version="1.0.3" />
-    <PackageReference Include="QueryInterceptor.Core" Version="1.0.5" />
-    <PackageReference Include="EntityFramework" Version="6.1.3" />
-    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="NFluent" Version="2.0.0-alpha" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
+        <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+        <PackageReference Include="Linq.PropertyTranslator.Core" Version="1.0.3" />
+        <PackageReference Include="QueryInterceptor.Core" Version="1.0.5" />
+        <PackageReference Include="EntityFramework" Version="6.1.3" />
+        <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.1" />
+        <PackageReference Include="xunit" Version="2.3.1" />
+        <PackageReference Include="NFluent" Version="2.1.1" />
+        <PackageReference Include="Moq" Version="4.10.0" />
+    </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+        <Reference Include="System" />
+        <Reference Include="Microsoft.CSharp" />
+    </ItemGroup>
 
 </Project>

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -88,7 +88,7 @@ namespace System.Linq.Dynamic.Core.Tests
             }
         }
 
-        private class TestCustomTypeProvider : AbstractDynamicLinqCustomTypeProvider, IDynamicLinkCustomTypeProvider
+        public class TestCustomTypeProvider : AbstractDynamicLinqCustomTypeProvider, IDynamicLinkCustomTypeProvider
         {
             private HashSet<Type> _customTypes;
 

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionPromoterTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionPromoterTests.cs
@@ -1,6 +1,53 @@
-﻿namespace System.Linq.Dynamic.Core.Tests
+﻿using System.Linq.Dynamic.Core.Parser;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace System.Linq.Dynamic.Core.Tests
 {
-    class ExpressionPromoterTests
+    public class CustomExpressionPromoter : ExpressionPromoter
     {
+        public override Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)
+        {
+            var result = base.Promote(expr, type, exact, convertExpr);
+
+            if (result == null)
+            {
+                if (type == typeof(string) && expr.Type == typeof(Guid))
+                {
+                    var ce = expr as ConstantExpression;
+
+                    if (Guid.TryParse(Convert.ToString(ce?.Value), out var guid))
+                    {
+                        return Expression.Constant(guid, type);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+
+    public class SampleDto
+    {
+        public Guid data;
+    }
+
+    /// <summary>
+    /// Test for the expression promoter
+    /// </summary>
+    public class ExpressionPromoterTests
+    {
+        [Fact]
+        public void PromoteGuidTest()
+        {
+            // Act
+            string query = $"new {typeof(SampleDto).FullName}(@0 as data)";
+            LambdaExpression expression = DynamicExpressionParser.ParseLambda(null, query, new object[] { Guid.NewGuid().ToString() });
+            Delegate del = expression.Compile();
+            SampleDto result = (SampleDto) del.DynamicInvoke();
+
+            // Assert
+            Assert.NotNull(result);
+        }
     }
 }

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionPromoterTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionPromoterTests.cs
@@ -40,9 +40,14 @@ namespace System.Linq.Dynamic.Core.Tests
         [Fact]
         public void PromoteGuidTest()
         {
+            var parsingConfig = new ParsingConfig()
+            {
+                AllowNewToEvaluateAnyType = true
+            };
+
             // Act
             string query = $"new {typeof(SampleDto).FullName}(@0 as data)";
-            LambdaExpression expression = DynamicExpressionParser.ParseLambda(null, query, new object[] { Guid.NewGuid().ToString() });
+            LambdaExpression expression = DynamicExpressionParser.ParseLambda(parsingConfig, null, query, new object[] { Guid.NewGuid().ToString() });
             Delegate del = expression.Compile();
             SampleDto result = (SampleDto) del.DynamicInvoke();
 

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionPromoterTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionPromoterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Dynamic.Core.Parser;
+﻿using System.Linq.Dynamic.Core.CustomTypeProviders;
+using System.Linq.Dynamic.Core.Parser;
 using System.Linq.Expressions;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace System.Linq.Dynamic.Core.Tests
 
             if (result == null)
             {
-                if (type == typeof(string) && expr.Type == typeof(Guid))
+                if (type == typeof(Guid) && expr.Type == typeof(string))
                 {
                     var ce = expr as ConstantExpression;
 
@@ -29,7 +30,7 @@ namespace System.Linq.Dynamic.Core.Tests
 
     public class SampleDto
     {
-        public Guid data;
+        public Guid data { get; set; }
     }
 
     /// <summary>
@@ -42,7 +43,9 @@ namespace System.Linq.Dynamic.Core.Tests
         {
             var parsingConfig = new ParsingConfig()
             {
-                AllowNewToEvaluateAnyType = true
+                AllowNewToEvaluateAnyType = true,
+                CustomTypeProvider = new DefaultDynamicLinqCustomTypeProvider(),
+                ExpressionPromoter = new CustomExpressionPromoter()
             };
 
             // Act

--- a/test/System.Linq.Dynamic.Core.Tests/System.Linq.Dynamic.Core.Tests.csproj
+++ b/test/System.Linq.Dynamic.Core.Tests/System.Linq.Dynamic.Core.Tests.csproj
@@ -35,6 +35,7 @@
             <Version>2.3.1</Version>
         </PackageReference>
         <PackageReference Include="NFluent" Version="2.1.1" />
+        <PackageReference Include="Moq" Version="4.10.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
Now that the library allows to instantiate more .Net types easily, Expression promoter needs to be more powerful depending on the needs of the destination types.

This PR makes it plugable and replaceable from outside the library.