### PR TITLE
Issue215

### DIFF
--- a/src/System.Linq.Dynamic.Core/DynamicClassFactory.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicClassFactory.cs
@@ -264,7 +264,10 @@ namespace System.Linq.Dynamic.Core
                             ilgeneratorToString.Emit(OpCodes.Pop);
                         }
 
-                        if (createParameterCtor)
+                        // Only create the default and with params constructor when there are any params.
+                        // Otherwise default constructor is not needed because it matches the default
+                        // one provided by the runtime when no constructor is present
+                        if (createParameterCtor && names.Any())
                         {
                             // .ctor default
                             ConstructorBuilder constructorDef = tb.DefineConstructor(MethodAttributes.Public | MethodAttributes.HideBySig, CallingConventions.HasThis, EmptyTypes);

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -1531,11 +1531,13 @@ namespace System.Linq.Dynamic.Core.Parser
                 return Expression.Dynamic(new DynamicGetMemberBinder(id), type, instance);
             }
 #endif
-
-            MethodInfo indexerMethod = instance.Type.GetMethod("get_Item", new[] { typeof(string) });
-            if (indexerMethod != null)
+            if (!_parsingConfig.DisableMemberAccessToIndexAccesorDowncast)
             {
-                return Expression.Call(instance, indexerMethod, Expression.Constant(id));
+                MethodInfo indexerMethod = instance.Type.GetMethod("get_Item", new[] {typeof(string)});
+                if (indexerMethod != null)
+                {
+                    return Expression.Call(instance, indexerMethod, Expression.Constant(id));
+                }
             }
 
             if (_textParser.CurrentToken.Id == TokenId.Lambda && _it.Type == type)

--- a/src/System.Linq.Dynamic.Core/ParsingConfig.cs
+++ b/src/System.Linq.Dynamic.Core/ParsingConfig.cs
@@ -103,5 +103,12 @@ namespace System.Linq.Dynamic.Core
         /// Renames the (Typed)ParameterExpression empty Name to a the correct supplied name from `it`. Default value is false.
         /// </summary>
         public bool RenameParameterExpression { get; set; } = false;
+
+        /// <summary>
+        /// By default when a member is not found in a type and the type has a string bassed index accessor it will be parsed as an index accesor. Use
+        /// this flag to disable this behaviour and have parsing fail when parsing an expression
+        /// where a member access on a non existing member happens
+        /// </summary>
+        public bool DisableMemberAccessToIndexAccesorDowncast { get; set; } = false;
     }
 }

--- a/test/System.Linq.Dynamic.Core.Tests/EntitiesTests.Select.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/EntitiesTests.Select.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq.Dynamic.Core.Tests.Helpers.Entities;
+using MongoDB.Bson;
 #if EFCORE
 using Microsoft.EntityFrameworkCore;
 #else
@@ -46,6 +47,24 @@ namespace System.Linq.Dynamic.Core.Tests
 
             //Assert
             Assert.Equal<ICollection>(expected, test);
+        }
+
+        [Fact]
+        public void Entities_Select_EmptyObject()
+        {
+            ParsingConfig config = ParsingConfig.Default;
+            config.EvaluateGroupByAtDatabase = true;
+
+            //Arrange
+            PopulateTestData(5, 0);
+
+            var expected = _context.Blogs.Select(x => new {}).ToList(); ;
+
+            //Act
+            var test = _context.Blogs.GroupBy(config, "BlogId", "new()").Select<object>("new()").ToList();
+
+            //Assert
+            Assert.Equal(expected.ToJson(), test.ToJson());
         }
 
         [Fact]


### PR DESCRIPTION
2 Changes in this PR.

* DynamicClassFactory.cs no longer creates a parameter constructor y the class has no properties. Prior to this, a class with a duplicate empty constructor was created.

* Added DisableMemberAccessToIndexAccesorDowncast to disable automatic downcast/fallback to item accesor when a member is not found. This is an enhancement for developers because it helps early detection of badly created expressions that will fail to evaluate. Previous behaviour is respected as this is a new optional flag.