### PR TITLE
Adding support for overloaded op_Equality

### DIFF
--- a/src-console/System.Linq.Dynamic.Core.ConsoleTestApp.net40/ConsoleApp_net40_sqlite_original.csproj
+++ b/src-console/System.Linq.Dynamic.Core.ConsoleTestApp.net40/ConsoleApp_net40_sqlite_original.csproj
@@ -94,6 +94,9 @@
     <Compile Include="..\..\test\System.Linq.Dynamic.Core.Tests\Helpers\Models\UserProfile.cs">
       <Link>Helpers\Models\UserProfile.cs</Link>
     </Compile>
+    <Compile Include="..\..\test\System.Linq.Dynamic.Core.Tests\Helpers\Models\SnowflakeId.cs">
+      <Link>Helpers\Models\SnowflakeId.cs</Link>
+    </Compile>
     <Compile Include="..\..\test\System.Linq.Dynamic.Core.Tests\Helpers\TestEnum.cs">
       <Link>Helpers\TestEnum.cs</Link>
     </Compile>
@@ -102,7 +105,7 @@
     </Compile>
     <Compile Include="..\..\test\System.Linq.Dynamic.Core.Tests\Helpers\Models\UserState.cs">
       <Link>Helpers\Models\UserState.cs</Link>
-    </Compile>	
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -266,7 +266,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 Token op = _textParser.CurrentToken;
                 _textParser.NextToken();
                 Expression right = ParseComparisonOperator();
-                CheckAndPromoteOperands(typeof(ILogicalSignatures), op.Id,op.Text, ref left, ref right, op.Pos);
+                CheckAndPromoteOperands(typeof(ILogicalSignatures), op.Id, op.Text, ref left, ref right, op.Pos);
                 left = Expression.AndAlso(left, right);
             }
             return left;
@@ -1910,8 +1910,7 @@ namespace System.Linq.Dynamic.Core.Parser
             }
         }
 
-        void CheckAndPromoteOperands(Type signatures, TokenId opId, string opName, ref Expression left,
-            ref Expression right, int errorPos)
+        void CheckAndPromoteOperands(Type signatures, TokenId opId, string opName, ref Expression left, ref Expression right, int errorPos)
         {
             Expression[] args = { left, right };
             

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -1920,10 +1920,10 @@ namespace System.Linq.Dynamic.Core.Parser
 
             if (nativeOperation != null)
             {
-                if (left is ConstantExpression)
+                // first try left operand's equality operators
+                found = _methodFinder.ContainsMethod(left.Type, nativeOperation, true, args);
+                if (!found)
                     found = _methodFinder.ContainsMethod(right.Type, nativeOperation, true, args);
-                else if (right is ConstantExpression)
-                    found = _methodFinder.ContainsMethod(left.Type, nativeOperation, true, args);
             }
 
             if (!found && !_methodFinder.ContainsMethod(signatures, "F", false, args))

--- a/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
+++ b/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
@@ -250,6 +250,9 @@
     <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\Models\UserState.cs">
       <Link>Helpers\Models\UserState.cs</Link>
     </Compile>
+    <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\Models\SnowflakeId.cs">
+      <Link>Helpers\Models\SnowflakeId.cs</Link>
+    </Compile>
     <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\TestEnum.cs">
       <Link>Helpers\TestEnum.cs</Link>
     </Compile>

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -143,7 +143,6 @@ namespace System.Linq.Dynamic.Core.Tests
             Check.That(value).IsEqualTo("x");
         }
 
-        
         [Fact]
         public void DynamicExpressionParser_ParseLambda_WithStructWithEquality()
         {
@@ -152,7 +151,7 @@ namespace System.Linq.Dynamic.Core.Tests
             var qry = testList.AsQueryable();
 
             // Act
-            var expectedX = (ulong) long.MaxValue + 3;
+            ulong expectedX = (ulong) long.MaxValue + 3;
 
             string query = $"Where(x => x.SnowflakeId == {expectedX})";
             LambdaExpression expression = DynamicExpressionParser.ParseLambda(qry.GetType(), null, query);

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1696,6 +1696,24 @@ namespace System.Linq.Dynamic.Core.Tests
         }
 
         [Fact]
+        public void ExpressionTests_Type_StructWithIntegerEquality()
+        {
+            // Arrange
+            var valuesL = new[] { new SnowflakeId(1L), new SnowflakeId(100), new SnowflakeId(5) }.AsQueryable();
+            var resultValuesL = new[] { new SnowflakeId(100) }.AsQueryable();
+
+            // Act
+            var resultL = valuesL.Where("it == 100");
+            var resultNL = valuesL.Where("it != 1 && it != 5");
+            var resultIn = valuesL.Where("it in (100)");
+
+            // Assert
+            Assert.Equal(resultValuesL.ToArray(), resultL);
+            Assert.Equal(resultValuesL.ToArray(), resultNL);
+            Assert.Equal(resultValuesL.ToArray(), resultIn);
+        }
+
+        [Fact]
         public void ExpressionTests_Type_Integer_Qualifiers_Negative()
         {
             // Arrange

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1705,11 +1705,13 @@ namespace System.Linq.Dynamic.Core.Tests
             // Act
             var resultL = valuesL.Where("it == 100");
             var resultNL = valuesL.Where("it != 1 && it != 5");
+            var resultArg = valuesL.Where("it == @0", 100);
             var resultIn = valuesL.Where("it in (100)");
 
             // Assert
             Assert.Equal(resultValuesL.ToArray(), resultL);
             Assert.Equal(resultValuesL.ToArray(), resultNL);
+            Assert.Equal(resultValuesL.ToArray(), resultArg);
             Assert.Equal(resultValuesL.ToArray(), resultIn);
         }
 

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1716,6 +1716,43 @@ namespace System.Linq.Dynamic.Core.Tests
         }
 
         [Fact]
+        public void ExpressionTests_Type_StructWithIntegerEquality_BothVariablesInStruct()
+        {
+            // Arrange
+            var valuesL = new[]
+            {
+                new
+                {
+                    Id = new SnowflakeId(1L), 
+                    Var = 1
+                },
+                new
+                {
+                    Id = new SnowflakeId(2L), 
+                    Var = 1
+                },
+                new
+                {
+                    Id = new SnowflakeId(1L), 
+                    Var = 2
+                }
+            }.AsQueryable();
+
+            var resultValuesL = new[] { 
+                new {
+                    Id = new SnowflakeId(1L), 
+                    Var = 1
+                }
+            }.AsQueryable();
+
+            // Act
+            var resultL = valuesL.Where("it.Id == it.Var");
+
+            // Assert
+            Assert.Equal(resultValuesL.ToArray(), resultL);
+        }
+
+        [Fact]
         public void ExpressionTests_Type_Integer_Qualifiers_Negative()
         {
             // Arrange

--- a/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/SnowflakeId.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/SnowflakeId.cs
@@ -1,0 +1,57 @@
+namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
+{
+    public struct SnowflakeId : IEquatable<SnowflakeId>
+    {
+        public bool Equals(SnowflakeId other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is SnowflakeId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(SnowflakeId left, SnowflakeId right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(SnowflakeId left, SnowflakeId right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static bool operator ==(SnowflakeId left, int right)
+        {
+            return (int)left.Value == right;
+        }
+
+        public static bool operator !=(SnowflakeId left, int right)
+        {
+            return (int)left.Value != right;
+        }
+
+        public static bool operator ==(SnowflakeId left, ulong right)
+        {
+            return left.Value == right;
+        }
+
+        public static bool operator !=(SnowflakeId left, ulong right)
+        {
+            return left.Value != right;
+        }
+
+        public ulong Value { get; }
+
+        public SnowflakeId(ulong value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/User.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/User.cs
@@ -6,6 +6,8 @@ namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
     {
         public Guid Id { get; set; }
 
+        public SnowflakeId SnowflakeId { get; set; }
+
         public string UserName { get; set; }
 
         public int? NullableInt { get; set; }
@@ -42,6 +44,7 @@ namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
                 var user = new User
                 {
                     Id = Guid.NewGuid(),
+                    SnowflakeId = new SnowflakeId(((ulong)long.MaxValue + (ulong)i + 2UL)),
                     UserName = "User" + i,
                     Income = 1 + (i % 15) * 100
                 };


### PR DESCRIPTION
Issue https://github.com/StefH/System.Linq.Dynamic.Core/issues/272. 

When the types mismatch, but support overloaded Equality/Inequality operators, use those.