### PR TITLE
op_Compare also for single "equals" token

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -1902,6 +1902,7 @@ namespace System.Linq.Dynamic.Core.Parser
             switch (tokenId)
             {
                 case TokenId.DoubleEqual:
+                case TokenId.Equal:
                     return "op_Equality";
                 case TokenId.ExclamationEqual:
                     return "op_Inequality";

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -143,8 +143,10 @@ namespace System.Linq.Dynamic.Core.Tests
             Check.That(value).IsEqualTo("x");
         }
 
-        [Fact]
-        public void DynamicExpressionParser_ParseLambda_WithStructWithEquality()
+        [Theory]
+        [InlineData("Where(x => x.SnowflakeId == {0})")]
+        [InlineData("Where(x => x.SnowflakeId = {0})")]
+        public void DynamicExpressionParser_ParseLambda_WithStructWithEquality(string query)
         {
             // Assign
             var testList = User.GenerateSampleModels(51);
@@ -153,7 +155,7 @@ namespace System.Linq.Dynamic.Core.Tests
             // Act
             ulong expectedX = (ulong) long.MaxValue + 3;
 
-            string query = $"Where(x => x.SnowflakeId == {expectedX})";
+            query = string.Format(query, expectedX);
             LambdaExpression expression = DynamicExpressionParser.ParseLambda(qry.GetType(), null, query);
             Delegate del = expression.Compile();
             IEnumerable<dynamic> result = del.DynamicInvoke(qry) as IEnumerable<dynamic>;

--- a/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/ExpressionTests.cs
@@ -1704,14 +1704,18 @@ namespace System.Linq.Dynamic.Core.Tests
 
             // Act
             var resultL = valuesL.Where("it == 100");
+            var resultLs = valuesL.Where("it = 100");
             var resultNL = valuesL.Where("it != 1 && it != 5");
             var resultArg = valuesL.Where("it == @0", 100);
+            var resultArgs = valuesL.Where("it = @0", 100);
             var resultIn = valuesL.Where("it in (100)");
 
             // Assert
             Assert.Equal(resultValuesL.ToArray(), resultL);
+            Assert.Equal(resultValuesL.ToArray(), resultLs);
             Assert.Equal(resultValuesL.ToArray(), resultNL);
             Assert.Equal(resultValuesL.ToArray(), resultArg);
+            Assert.Equal(resultValuesL.ToArray(), resultArgs);
             Assert.Equal(resultValuesL.ToArray(), resultIn);
         }
 
@@ -1743,13 +1747,15 @@ namespace System.Linq.Dynamic.Core.Tests
                     Id = new SnowflakeId(1L), 
                     Var = 1
                 }
-            }.AsQueryable();
+            }.AsQueryable().ToArray();
 
             // Act
             var resultL = valuesL.Where("it.Id == it.Var");
+            var resultLs = valuesL.Where("it.Id = it.Var");
 
             // Assert
             Assert.Equal(resultValuesL.ToArray(), resultL);
+            Assert.Equal(resultValuesL.ToArray(), resultLs);
         }
 
         [Fact]


### PR DESCRIPTION
I realized I've made mistake in my previous PR. query `a = b` is considered equal to `a == b`, but the `op_Equality` detection does not take single equals token into consideration.