### PR TITLE
Fix certain cases where implicit conversions aren't correctly detected when parsing comparison operators

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -543,9 +543,16 @@ namespace System.Linq.Dynamic.Core.Parser
 
         private bool HasImplicitConversion(Type baseType, Type targetType)
         {
-            var methods = baseType.GetMethods(BindingFlags.Public | BindingFlags.Static).ToList();
-            methods.AddRange(targetType.GetMethods(BindingFlags.Public | BindingFlags.Static));
-            return methods
+            var baseTypeHasConversion = baseType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(mi => mi.Name == "op_Implicit" && mi.ReturnType == targetType)
+                .Any(mi => mi.GetParameters().FirstOrDefault()?.ParameterType == baseType);
+
+            if (baseTypeHasConversion)
+            {
+                return true;
+            }
+
+            return targetType.GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .Where(mi => mi.Name == "op_Implicit" && mi.ReturnType == targetType)
                 .Any(mi => mi.GetParameters().FirstOrDefault()?.ParameterType == baseType);
         }

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -543,7 +543,9 @@ namespace System.Linq.Dynamic.Core.Parser
 
         private bool HasImplicitConversion(Type baseType, Type targetType)
         {
-            return baseType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            var methods = baseType.GetMethods(BindingFlags.Public | BindingFlags.Static).ToList();
+            methods.AddRange(targetType.GetMethods(BindingFlags.Public | BindingFlags.Static));
+            return methods
                 .Where(mi => mi.Name == "op_Implicit" && mi.ReturnType == targetType)
                 .Any(mi => mi.GetParameters().FirstOrDefault()?.ParameterType == baseType);
         }

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -430,11 +430,11 @@ namespace System.Linq.Dynamic.Core.Parser
                     // If left or right is NullLiteral, just continue. Else check if the types differ.
                     if (!(Constants.IsNull(left) || Constants.IsNull(right)) && left.Type != right.Type)
                     {
-                        if (left.Type.IsAssignableFrom(right.Type))
+                        if (left.Type.IsAssignableFrom(right.Type) || HasImplicitConversion(right.Type, left.Type))
                         {
                             right = Expression.Convert(right, left.Type);
                         }
-                        else if (right.Type.IsAssignableFrom(left.Type))
+                        else if (right.Type.IsAssignableFrom(left.Type) || HasImplicitConversion(left.Type, right.Type))
                         {
                             left = Expression.Convert(left, right.Type);
                         }

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -788,25 +788,18 @@ namespace System.Linq.Dynamic.Core.Tests
         }
 
         [Fact]
-        public void DynamicExpressionParser_ParseLambda_With_Implicit_Conversions()
+        public void DynamicExpressionParser_ParseLambda_With_One_Way_Implicit_Conversions()
         {
             // Arrange
             var testValue = "test";
             var container = new TestImplicitConversionContainer(testValue);
             var expressionText = $"OneWay == \"{testValue}\"";
 
-            // Act 1
+            // Act
             var lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionText);
 
-            // Assert 1
+            // Assert
             Assert.NotNull(lambda);
-
-            // Act 2
-            var del = lambda.Compile();
-            bool result = (bool)del.DynamicInvoke(container);
-
-            // Assert 2
-            Assert.True(result);
         }
 
         [Fact]

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -1,10 +1,10 @@
-﻿using NFluent;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq.Dynamic.Core.CustomTypeProviders;
 using System.Linq.Dynamic.Core.Exceptions;
 using System.Linq.Dynamic.Core.Tests.Helpers.Models;
 using System.Linq.Expressions;
 using System.Reflection;
+using NFluent;
 using Xunit;
 using User = System.Linq.Dynamic.Core.Tests.Helpers.Models.User;
 
@@ -62,6 +62,36 @@ namespace System.Linq.Dynamic.Core.Tests
             {
                 return Origin;
             }
+        }
+
+        public class CustomClassWithOneWayImplicitConversion
+        {
+            public CustomClassWithOneWayImplicitConversion(string origin)
+            {
+                Origin = origin;
+            }
+
+            public string Origin { get; }
+
+            public static implicit operator CustomClassWithOneWayImplicitConversion(string origin)
+            {
+                return new CustomClassWithOneWayImplicitConversion(origin);
+            }
+
+            public override string ToString()
+            {
+                return Origin;
+            }
+        }
+
+        public class TestImplicitConversionContainer
+        {
+            public TestImplicitConversionContainer(CustomClassWithOneWayImplicitConversion oneWay)
+            {
+                OneWay = oneWay;
+            }
+
+            public CustomClassWithOneWayImplicitConversion OneWay { get; }
         }
 
         public class TextHolder
@@ -755,6 +785,28 @@ namespace System.Linq.Dynamic.Core.Tests
 
             // Assert 2
             Assert.Equal("note1 (name1)", result);
+        }
+
+        [Fact]
+        public void DynamicExpressionParser_ParseLambda_With_Implicit_Conversions()
+        {
+            // Arrange
+            var testValue = "test";
+            var container = new TestImplicitConversionContainer(testValue);
+            var expressionText = $"OneWay == \"{testValue}\"";
+
+            // Act 1
+            var lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionText);
+
+            // Assert 1
+            Assert.NotNull(lambda);
+
+            // Act 2
+            var del = lambda.Compile();
+            bool result = (bool)del.DynamicInvoke(container);
+
+            // Assert 2
+            Assert.True(result);
         }
 
         [Fact]


### PR DESCRIPTION
Hello, all.

I discovered a few edge cases where implicit conversions defined between two types would not be used when parsing comparison operators:

- The parser only searches for implicit conversions on the type which is being converted, and not the target type. If the conversion is only defined on the target type, it is missed, resulting in a parse failure.
- The parser doesn't check for implicit conversions at all when parsing equality comparisons on non-value types. If both types are non-value types (e.g. class and string), implicit conversions won't be considered at all.

I added a test which reproduces both cases, as well as fixes for these issues. The test now passes with the fixes for both issues applied.

Please let me know how I can improve the fixes here. Thanks!

