### PR TITLE
Ensure that one-way implicit conversions also work for value types

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -504,13 +504,27 @@ namespace System.Linq.Dynamic.Core.Parser
 
                     if (!typesAreSameAndImplementCorrectInterface)
                     {
-                        if (left.Type.GetTypeInfo().IsClass && right is ConstantExpression && HasImplicitConversion(left.Type, right.Type))
+                        if (left.Type.GetTypeInfo().IsClass && right is ConstantExpression)
                         {
-                            left = Expression.Convert(left, right.Type);
+                            if (HasImplicitConversion(left.Type, right.Type))
+                            {
+                                left = Expression.Convert(left, right.Type);
+                            }
+                            else if (HasImplicitConversion(right.Type, left.Type))
+                            {
+                                right = Expression.Convert(right, left.Type);
+                            }
                         }
-                        else if (right.Type.GetTypeInfo().IsClass && left is ConstantExpression && HasImplicitConversion(right.Type, left.Type))
+                        else if (right.Type.GetTypeInfo().IsClass && left is ConstantExpression)
                         {
-                            right = Expression.Convert(right, left.Type);
+                            if (HasImplicitConversion(right.Type, left.Type))
+                            {
+                                right = Expression.Convert(right, left.Type);
+                            }
+                            else if (HasImplicitConversion(left.Type, right.Type))
+                            {
+                                left = Expression.Convert(left, right.Type);
+                            }
                         }
                         else
                         {

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -84,6 +84,26 @@ namespace System.Linq.Dynamic.Core.Tests
             }
         }
 
+        public class CustomClassWithReversedImplicitConversion
+        {
+            public CustomClassWithReversedImplicitConversion(string origin)
+            {
+                Origin = origin;
+            }
+
+            public string Origin { get; }
+
+            public static implicit operator string(CustomClassWithReversedImplicitConversion origin)
+            {
+                return origin.ToString();
+            }
+
+            public override string ToString()
+            {
+                return Origin;
+            }
+        }
+
         public class CustomClassWithValueTypeImplicitConversion
         {
             public CustomClassWithValueTypeImplicitConversion(int origin)
@@ -104,17 +124,47 @@ namespace System.Linq.Dynamic.Core.Tests
             }
         }
 
+        public class CustomClassWithReversedValueTypeImplicitConversion
+        {
+            public CustomClassWithReversedValueTypeImplicitConversion(int origin)
+            {
+                Origin = origin;
+            }
+
+            public int Origin { get; }
+
+            public static implicit operator int(CustomClassWithReversedValueTypeImplicitConversion origin)
+            {
+                return origin.Origin;
+            }
+
+            public override string ToString()
+            {
+                return Origin.ToString();
+            }
+        }
+
         public class TestImplicitConversionContainer
         {
-            public TestImplicitConversionContainer(CustomClassWithOneWayImplicitConversion oneWay, CustomClassWithValueTypeImplicitConversion valueType)
+            public TestImplicitConversionContainer(
+                CustomClassWithOneWayImplicitConversion oneWay,
+                CustomClassWithReversedImplicitConversion reversed,
+                CustomClassWithValueTypeImplicitConversion valueType,
+                CustomClassWithReversedValueTypeImplicitConversion reversedValueType)
             {
                 OneWay = oneWay;
+                Reversed = Reversed;
                 ValueType = valueType;
+                ReversedValueType = reversedValueType;
             }
 
             public CustomClassWithOneWayImplicitConversion OneWay { get; }
 
+            public CustomClassWithReversedImplicitConversion Reversed { get; }
+
             public CustomClassWithValueTypeImplicitConversion ValueType { get; }
+
+            public CustomClassWithReversedValueTypeImplicitConversion ReversedValueType { get; }
         }
 
         public class TextHolder
@@ -816,9 +866,11 @@ namespace System.Linq.Dynamic.Core.Tests
             // Arrange
             var testString = "test";
             var testInt = 6;
-            var container = new TestImplicitConversionContainer(testString, testInt);
+            var container = new TestImplicitConversionContainer(testString, new CustomClassWithReversedImplicitConversion(testString), testInt, new CustomClassWithReversedValueTypeImplicitConversion(testInt));
             var expressionTextString = $"OneWay == \"{testString}\"";
-            var expressionTextValueType = $"ValueType == \"{testInt}\"";
+            var expressionTextReversed = $"Reversed == \"{testString}\"";
+            var expressionTextValueType = $"ValueType == {testInt}";
+            var expressionTextReversedValueType = $"ReversedValueType == {testInt}";
 
             // Act 1
             var lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextString);
@@ -827,9 +879,21 @@ namespace System.Linq.Dynamic.Core.Tests
             Assert.NotNull(lambda);
 
             // Act 2
-            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextString);
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextReversed);
 
             // Assert 2
+            Assert.NotNull(lambda);
+
+            // Act 3
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextValueType);
+
+            // Assert 3
+            Assert.NotNull(lambda);
+
+            // Act 4
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextReversedValueType);
+
+            // Assert 4
             Assert.NotNull(lambda);
         }
 

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -867,10 +867,16 @@ namespace System.Linq.Dynamic.Core.Tests
             var testString = "test";
             var testInt = 6;
             var container = new TestImplicitConversionContainer(testString, new CustomClassWithReversedImplicitConversion(testString), testInt, new CustomClassWithReversedValueTypeImplicitConversion(testInt));
+
             var expressionTextString = $"OneWay == \"{testString}\"";
             var expressionTextReversed = $"Reversed == \"{testString}\"";
             var expressionTextValueType = $"ValueType == {testInt}";
             var expressionTextReversedValueType = $"ReversedValueType == {testInt}";
+
+            var invertedExpressionTextString = $"\"{testString}\" == OneWay";
+            var invertedExpressionTextReversed = $"\"{testString}\" == Reversed";
+            var invertedExpressionTextValueType = $"{testInt} == ValueType";
+            var invertedExpressionTextReversedValueType = $"{testInt} == ReversedValueType";
 
             // Act 1
             var lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextString);
@@ -894,6 +900,30 @@ namespace System.Linq.Dynamic.Core.Tests
             lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextReversedValueType);
 
             // Assert 4
+            Assert.NotNull(lambda);
+
+            // Act 5
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, invertedExpressionTextString);
+
+            // Assert 5
+            Assert.NotNull(lambda);
+
+            // Act 6
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, invertedExpressionTextReversed);
+
+            // Assert 6
+            Assert.NotNull(lambda);
+
+            // Act 7
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, invertedExpressionTextValueType);
+
+            // Assert 7
+            Assert.NotNull(lambda);
+
+            // Act 8
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, invertedExpressionTextReversedValueType);
+
+            // Assert 8
             Assert.NotNull(lambda);
         }
 

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -84,14 +84,37 @@ namespace System.Linq.Dynamic.Core.Tests
             }
         }
 
+        public class CustomClassWithValueTypeImplicitConversion
+        {
+            public CustomClassWithValueTypeImplicitConversion(int origin)
+            {
+                Origin = origin;
+            }
+
+            public int Origin { get; }
+
+            public static implicit operator CustomClassWithValueTypeImplicitConversion(int origin)
+            {
+                return new CustomClassWithValueTypeImplicitConversion(origin);
+            }
+
+            public override string ToString()
+            {
+                return Origin.ToString();
+            }
+        }
+
         public class TestImplicitConversionContainer
         {
-            public TestImplicitConversionContainer(CustomClassWithOneWayImplicitConversion oneWay)
+            public TestImplicitConversionContainer(CustomClassWithOneWayImplicitConversion oneWay, CustomClassWithValueTypeImplicitConversion valueType)
             {
                 OneWay = oneWay;
+                ValueType = valueType;
             }
 
             public CustomClassWithOneWayImplicitConversion OneWay { get; }
+
+            public CustomClassWithValueTypeImplicitConversion ValueType { get; }
         }
 
         public class TextHolder
@@ -791,14 +814,22 @@ namespace System.Linq.Dynamic.Core.Tests
         public void DynamicExpressionParser_ParseLambda_With_One_Way_Implicit_Conversions()
         {
             // Arrange
-            var testValue = "test";
-            var container = new TestImplicitConversionContainer(testValue);
-            var expressionText = $"OneWay == \"{testValue}\"";
+            var testString = "test";
+            var testInt = 6;
+            var container = new TestImplicitConversionContainer(testString, testInt);
+            var expressionTextString = $"OneWay == \"{testString}\"";
+            var expressionTextValueType = $"ValueType == \"{testInt}\"";
 
-            // Act
-            var lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionText);
+            // Act 1
+            var lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextString);
 
-            // Assert
+            // Assert 1
+            Assert.NotNull(lambda);
+
+            // Act 2
+            lambda = DynamicExpressionParser.ParseLambda<TestImplicitConversionContainer, bool>(ParsingConfig.Default, false, expressionTextString);
+
+            // Assert 2
             Assert.NotNull(lambda);
         }
 


### PR DESCRIPTION
My previous PR (#285) fixed a couple issues with one-way implicit conversions, but we still aren't properly checking which type is promotable when comparing value types.

Added some extra logic to fix this. When comparing a value type against a class, we now check for implicit conversions both ways (value type to class, and class to value type). This was already fixed for non-value types, which are handled in a different section of the logic.

Updated the test to hit both the value-type case and the non-value-type case.