### PR TITLE
Prioritize property or field over the type / Fix find for static property or field

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -981,7 +981,9 @@ namespace System.Linq.Dynamic.Core.Parser
         {
             _textParser.ValidateToken(TokenId.Identifier);
 
-            if (_keywordsHelper.TryGetValue(_textParser.CurrentToken.Text, out object value))
+            if (_keywordsHelper.TryGetValue(_textParser.CurrentToken.Text, out object value) &&
+                    // When the type and property have the same name the parser takes the property instead of type
+                    !(value is Type && _it != null && FindPropertyOrField(_it.Type, _textParser.CurrentToken.Text, false) != null))
             {
                 Type typeValue = value as Type;
                 if (typeValue != null)

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -982,8 +982,8 @@ namespace System.Linq.Dynamic.Core.Parser
             _textParser.ValidateToken(TokenId.Identifier);
 
             if (_keywordsHelper.TryGetValue(_textParser.CurrentToken.Text, out object value) &&
-                    // When the type and property have the same name the parser takes the property instead of type
-                    !(value is Type && _it != null && FindPropertyOrField(_it.Type, _textParser.CurrentToken.Text, false) != null))
+                // Prioritize property or field over the type
+                !(value is Type && _it != null && FindPropertyOrField(_it.Type, _textParser.CurrentToken.Text, false) != null))
             {
                 Type typeValue = value as Type;
                 if (typeValue != null)
@@ -1691,7 +1691,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 return Expression.Dynamic(new DynamicGetMemberBinder(id), type, instance);
             }
 #endif
-            if (!_parsingConfig.DisableMemberAccessToIndexAccessorFallback)
+            if (!_parsingConfig.DisableMemberAccessToIndexAccessorFallback && instance != null)
             {
                 MethodInfo indexerMethod = instance.Type.GetMethod("get_Item", new[] { typeof(string) });
                 if (indexerMethod != null)
@@ -2028,14 +2028,14 @@ namespace System.Linq.Dynamic.Core.Parser
             foreach (Type t in TypeHelper.GetSelfAndBaseTypes(type))
             {
                 // Try to find a property with the specified memberName
-                MemberInfo member = t.GetTypeInfo().DeclaredProperties.FirstOrDefault(x => x.Name.ToLowerInvariant() == memberName.ToLowerInvariant());
+                MemberInfo member = t.GetTypeInfo().DeclaredProperties.FirstOrDefault(x => (!staticAccess || x.GetAccessors(true)[0].IsStatic) && x.Name.ToLowerInvariant() == memberName.ToLowerInvariant());
                 if (member != null)
                 {
                     return member;
                 }
 
                 // If no property is found, try to get a field with the specified memberName
-                member = t.GetTypeInfo().DeclaredFields.FirstOrDefault(x => (x.IsStatic || !staticAccess) && x.Name.ToLowerInvariant() == memberName.ToLowerInvariant());
+                member = t.GetTypeInfo().DeclaredFields.FirstOrDefault(x => (!staticAccess || x.IsStatic) && x.Name.ToLowerInvariant() == memberName.ToLowerInvariant());
                 if (member != null)
                 {
                     return member;

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -5,7 +5,6 @@ using System.Linq.Dynamic.Core.Exceptions;
 using System.Linq.Dynamic.Core.Tests.Helpers.Models;
 using System.Linq.Expressions;
 using System.Reflection;
-using FluentAssertions;
 using Xunit;
 using User = System.Linq.Dynamic.Core.Tests.Helpers.Models.User;
 

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
@@ -153,6 +153,5 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
             // Assert
             Check.That(parsedExpression).Equals(result);
         }
-
     }
 }

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
@@ -1,6 +1,11 @@
-﻿using System.Linq.Dynamic.Core.Parser;
-using System.Linq.Expressions;
+﻿using Moq;
 using NFluent;
+using System.Collections.Generic;
+using System.Linq.Dynamic.Core.CustomTypeProviders;
+using System.Linq.Dynamic.Core.Exceptions;
+using System.Linq.Dynamic.Core.Parser;
+using System.Linq.Dynamic.Core.Tests.Entities;
+using System.Linq.Expressions;
 using Xunit;
 
 namespace System.Linq.Dynamic.Core.Tests.Parser
@@ -103,5 +108,51 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
             // Assert
             Check.That(constantExpression.Value).Equals(result);
         }
+
+        private readonly ParsingConfig _parsingConfig;
+        private readonly Mock<IDynamicLinkCustomTypeProvider> _dynamicTypeProviderMock;
+
+        public ExpressionParserTests()
+        {
+            _dynamicTypeProviderMock = new Mock<IDynamicLinkCustomTypeProvider>();
+            _dynamicTypeProviderMock.Setup(dt => dt.GetCustomTypes()).Returns(new HashSet<Type>() { typeof(Company), typeof(MainCompany) });
+            _dynamicTypeProviderMock.Setup(dt => dt.ResolveType(typeof(Company).FullName)).Returns(typeof(Company));
+            _dynamicTypeProviderMock.Setup(dt => dt.ResolveType(typeof(MainCompany).FullName)).Returns(typeof(MainCompany));
+            _dynamicTypeProviderMock.Setup(dt => dt.ResolveTypeBySimpleName("Company")).Returns(typeof(Company));
+            _dynamicTypeProviderMock.Setup(dt => dt.ResolveTypeBySimpleName("MainCompany")).Returns(typeof(MainCompany));
+
+            _parsingConfig = new ParsingConfig
+            {
+                CustomTypeProvider = _dynamicTypeProviderMock.Object
+            };
+        }
+
+        [Theory]
+        [InlineData("it.MainCompany.Name != null", "(company.MainCompany.Name != null)")]
+        [InlineData("@MainCompany.Companies.Count() > 0", "(company.MainCompany.Companies.Count() > 0)")]
+        [InlineData("Company.Equals(null, null)", "Equals(null, null)")]
+        [InlineData("MainCompany.Name", "company.MainCompany.Name")]
+        [InlineData("Company.Name", "No property or field 'Name' exists in type 'Company'")]
+        public void Parse_PrioritizePropertyOrFieldOverTheType(string expression, string result)
+        {
+            // Arrange
+            ParameterExpression[] parameters = { ParameterExpressionHelper.CreateParameterExpression(typeof(Company), "company") };
+            var sut = new ExpressionParser(parameters, expression, null, _parsingConfig);
+
+            // Act
+            string parsedExpression = null;
+            try
+            {
+                parsedExpression = sut.Parse(null).ToString();
+            }
+            catch (ParseException e)
+            {
+                parsedExpression = e.Message;
+            }
+
+            // Assert
+            Check.That(parsedExpression).Equals(result);
+        }
+
     }
 }


### PR DESCRIPTION
When the type and property have the same name the parser takes the property instead of type